### PR TITLE
Add JSON preview open option

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -7,3 +7,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507170201] Initialized Codex activity logging system and created CODEXLOG.md
 [2507170201][4f8aac][SNC][DOC] Injected task-based development workflow structure (AGENTS.md excluded)
 [2507172029][9b2e21][FTR] Added initial Swing app skeleton
+[2507172141][f62b84][FTR] Added Open menu with JSON preview

--- a/src/colog/Main.java
+++ b/src/colog/Main.java
@@ -1,8 +1,13 @@
 package colog;
 
 import javax.swing.*;
+import javax.swing.filechooser.FileNameExtensionFilter;
+
+import java.awt.*;
+import java.io.*;
 
 public class Main {
+    private static File lastDir;
     public static void main(String[] args) {
         SwingUtilities.invokeLater(() -> createAndShowGUI());
     }
@@ -15,12 +20,52 @@ public class Main {
 
         JMenuBar menuBar = new JMenuBar();
         JMenu fileMenu = new JMenu("File");
+
+        JMenuItem openItem = new JMenuItem("Open");
+        openItem.addActionListener(e -> handleOpen(frame));
+        fileMenu.add(openItem);
+
         JMenuItem exitItem = new JMenuItem("Exit");
         exitItem.addActionListener(e -> System.exit(0));
         fileMenu.add(exitItem);
+
         menuBar.add(fileMenu);
         frame.setJMenuBar(menuBar);
 
         frame.setVisible(true);
+    }
+
+    private static void handleOpen(JFrame parent) {
+        JFileChooser chooser = new JFileChooser(lastDir);
+        FileNameExtensionFilter filter = new FileNameExtensionFilter("JSON files", "json");
+        chooser.setFileFilter(filter);
+        int result = chooser.showOpenDialog(parent);
+        if (result == JFileChooser.APPROVE_OPTION) {
+            File selected = chooser.getSelectedFile();
+            lastDir = selected.getParentFile();
+            if (!selected.getName().toLowerCase().endsWith(".json")) {
+                JOptionPane.showMessageDialog(parent, "Please select a .json file.",
+                        "Invalid File", JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+            StringBuilder sb = new StringBuilder();
+            try (BufferedReader reader = new BufferedReader(new FileReader(selected))) {
+                String line;
+                for (int i = 0; i < 10 && (line = reader.readLine()) != null; i++) {
+                    sb.append(line).append(System.lineSeparator());
+                }
+            } catch (IOException ex) {
+                JOptionPane.showMessageDialog(parent, "Error reading file: " + ex.getMessage(),
+                        "Read Error", JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+
+            JTextArea area = new JTextArea(sb.toString(), 20, 60);
+            area.setEditable(false);
+            area.setCaretPosition(0);
+            JScrollPane scrollPane = new JScrollPane(area);
+            JOptionPane.showMessageDialog(parent, scrollPane, "File Preview",
+                    JOptionPane.INFORMATION_MESSAGE);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a File > Open option next to Exit
- show JFileChooser that remembers last directory and filters for `.json`
- preview first 10 lines of the selected file in a scrollable dialog
- log new feature in CODEX log

## Testing
- `javac -d out src/colog/Main.java`
- `java -cp out colog.Main` *(fails: java.awt.HeadlessException)*

------
https://chatgpt.com/codex/tasks/task_b_68796da9bd388321bb150985848c9629