### PR TITLE
Add conversation and exchange panels

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -8,3 +8,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507170201][4f8aac][SNC][DOC] Injected task-based development workflow structure (AGENTS.md excluded)
 [2507172029][9b2e21][FTR] Added initial Swing app skeleton
 [2507172141][f62b84][FTR] Added Open menu with JSON preview
+[2507172329][1c9c44][FTR] Added scrollable conversation and exchange panels

--- a/src/colog/ConversationPanel.java
+++ b/src/colog/ConversationPanel.java
@@ -1,0 +1,26 @@
+package colog;
+
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import javax.swing.border.LineBorder;
+import java.awt.*;
+import java.util.List;
+
+/**
+ * Container for multiple ExchangePanels representing a conversation.
+ */
+public class ConversationPanel extends JPanel {
+    public ConversationPanel(String title, List<ExchangePanel> exchanges) {
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setBorder(new LineBorder(Color.DARK_GRAY));
+        setAlignmentX(LEFT_ALIGNMENT);
+
+        JLabel titleLabel = new JLabel(title);
+        titleLabel.setBorder(new EmptyBorder(5, 5, 5, 5));
+        add(titleLabel);
+
+        for (ExchangePanel ex : exchanges) {
+            add(ex);
+        }
+    }
+}

--- a/src/colog/ExchangePanel.java
+++ b/src/colog/ExchangePanel.java
@@ -1,0 +1,41 @@
+package colog;
+
+import javax.swing.*;
+import javax.swing.border.LineBorder;
+import java.awt.*;
+
+/**
+ * A single exchange row with timestamp, summary, tags, and expand icon.
+ */
+public class ExchangePanel extends JPanel {
+    private static final int ROW_HEIGHT = 50;
+
+    public ExchangePanel(String timestamp, String summary, String tags) {
+        setLayout(new BorderLayout());
+        setBorder(new LineBorder(Color.LIGHT_GRAY));
+        setMaximumSize(new Dimension(Integer.MAX_VALUE, ROW_HEIGHT));
+        setPreferredSize(new Dimension(600, ROW_HEIGHT));
+
+        JLabel timeLabel = new JLabel(timestamp);
+        timeLabel.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
+        add(timeLabel, BorderLayout.WEST);
+
+        JLabel summaryLabel = new JLabel("<html>" + summary + "</html>");
+        summaryLabel.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
+        add(summaryLabel, BorderLayout.CENTER);
+
+        JPanel rightPanel = new JPanel();
+        rightPanel.setOpaque(false);
+        rightPanel.setLayout(new BoxLayout(rightPanel, BoxLayout.X_AXIS));
+
+        JLabel tagsLabel = new JLabel(tags);
+        tagsLabel.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
+        rightPanel.add(tagsLabel);
+
+        JLabel expandLabel = new JLabel("\u2BC8"); // placeholder icon
+        expandLabel.setBorder(BorderFactory.createEmptyBorder(0, 10, 0, 5));
+        rightPanel.add(expandLabel);
+
+        add(rightPanel, BorderLayout.EAST);
+    }
+}

--- a/src/colog/Main.java
+++ b/src/colog/Main.java
@@ -5,6 +5,7 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 
 import java.awt.*;
 import java.io.*;
+import java.util.List;
 
 public class Main {
     private static File lastDir;
@@ -31,6 +32,27 @@ public class Main {
 
         menuBar.add(fileMenu);
         frame.setJMenuBar(menuBar);
+
+        JPanel container = new JPanel();
+        container.setLayout(new BoxLayout(container, BoxLayout.Y_AXIS));
+
+        ConversationPanel c1 = new ConversationPanel("Conversation A", List.of(
+                new ExchangePanel("10:00", "Prompt about feature A", "tag1, tag2"),
+                new ExchangePanel("10:05", "Response summary A", "tag2")
+        ));
+
+        ConversationPanel c2 = new ConversationPanel("Conversation B", List.of(
+                new ExchangePanel("11:00", "Another prompt", "tagX"),
+                new ExchangePanel("11:05", "Another response", "tagY"),
+                new ExchangePanel("11:10", "Follow up question", "tagZ")
+        ));
+
+        container.add(c1);
+        container.add(Box.createRigidArea(new Dimension(0, 10)));
+        container.add(c2);
+
+        JScrollPane scrollPane = new JScrollPane(container);
+        frame.setContentPane(scrollPane);
 
         frame.setVisible(true);
     }


### PR DESCRIPTION
## Summary
- add `ExchangePanel` to show timestamp, summary, tags and expand icon
- add `ConversationPanel` for stacking exchange rows
- show two demo conversations in a scrollable main panel
- update activity log

## Testing
- `javac src/colog/*.java`

------
https://chatgpt.com/codex/tasks/task_b_6879870286348321836af5795d281c83