### PR TITLE
Add JSON parser and dynamic UI loading

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -9,3 +9,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507172029][9b2e21][FTR] Added initial Swing app skeleton
 [2507172141][f62b84][FTR] Added Open menu with JSON preview
 [2507172329][1c9c44][FTR] Added scrollable conversation and exchange panels
+[2507180129][c4000c][FTR] Integrated JSON parser and dynamic row loading

--- a/src/colog/Conversation.java
+++ b/src/colog/Conversation.java
@@ -1,0 +1,13 @@
+package colog;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Conversation {
+    public String title;
+    public List<Exchange> exchanges = new ArrayList<>();
+
+    public Conversation(String title) {
+        this.title = title;
+    }
+}

--- a/src/colog/Exchange.java
+++ b/src/colog/Exchange.java
@@ -1,0 +1,25 @@
+package colog;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Exchange {
+    public String timestamp;
+    public String prompt;
+    public String response;
+    public List<String> tags = new ArrayList<>();
+    public String summary;
+
+    public Exchange(String timestamp, String prompt, String response) {
+        this.timestamp = timestamp;
+        this.prompt = prompt;
+        this.response = response;
+        this.summary = generateSummary(prompt, response);
+    }
+
+    private String generateSummary(String prompt, String response) {
+        if (prompt == null || prompt.isBlank()) return "No summary";
+        int end = prompt.indexOf('\n');
+        return end > 0 ? prompt.substring(0, end).trim() : prompt.trim();
+    }
+}

--- a/src/colog/JsonParser.java
+++ b/src/colog/JsonParser.java
@@ -1,0 +1,95 @@
+package colog;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JsonParser {
+    private static final DateTimeFormatter TIME_FMT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault());
+
+    public static Conversation parseConversationFromFile(File file) throws IOException {
+        String content = Files.readString(file.toPath());
+        JSONObject root = new JSONObject(content);
+        String title = root.optString("title", file.getName());
+        Conversation conversation = new Conversation(title);
+
+        JSONObject mapping = root.getJSONObject("mapping");
+        String nodeId = "client-created-root";
+        JSONObject node = mapping.optJSONObject(nodeId);
+        if (node == null) return conversation;
+
+        List<String> queue = toList(node.optJSONArray("children"));
+        while (!queue.isEmpty()) {
+            nodeId = queue.remove(0);
+            node = mapping.optJSONObject(nodeId);
+            if (node == null) continue;
+            JSONObject message = node.optJSONObject("message");
+            if (message == null) {
+                queue.addAll(toList(node.optJSONArray("children")));
+                continue;
+            }
+            String role = message.optJSONObject("author").optString("role", "");
+            if ("user".equals(role)) {
+                String prompt = firstPart(message);
+                long ts = (long) message.optDouble("create_time", 0);
+                String timestamp = ts > 0 ? TIME_FMT.format(Instant.ofEpochSecond(ts)) : "";
+                String response = "";
+                JSONArray children = node.optJSONArray("children");
+                String nextId = null;
+                if (children != null) {
+                    for (int i = 0; i < children.length(); i++) {
+                        String cid = children.getString(i);
+                        JSONObject cnode = mapping.optJSONObject(cid);
+                        if (cnode != null) {
+                            JSONObject cm = cnode.optJSONObject("message");
+                            if (cm != null && "assistant".equals(cm.optJSONObject("author").optString("role"))) {
+                                response = firstPart(cm);
+                                nextId = cid;
+                                break;
+                            }
+                        }
+                    }
+                }
+                conversation.exchanges.add(new Exchange(timestamp, prompt, response));
+                if (nextId != null) {
+                    queue.clear();
+                    queue.addAll(toList(mapping.getJSONObject(nextId).optJSONArray("children")));
+                }
+            } else {
+                queue.addAll(toList(node.optJSONArray("children")));
+            }
+        }
+        return conversation;
+    }
+
+    private static List<String> toList(JSONArray arr) {
+        List<String> list = new ArrayList<>();
+        if (arr != null) {
+            for (int i = 0; i < arr.length(); i++) {
+                list.add(arr.getString(i));
+            }
+        }
+        return list;
+    }
+
+    private static String firstPart(JSONObject message) {
+        if (message == null) return "";
+        JSONObject content = message.optJSONObject("content");
+        if (content != null) {
+            JSONArray parts = content.optJSONArray("parts");
+            if (parts != null && parts.length() > 0) {
+                return parts.getString(0);
+            }
+        }
+        return "";
+    }
+}


### PR DESCRIPTION
## Summary
- create `Exchange` and `Conversation` data models
- parse ChatGPT exports with new `JsonParser`
- update UI to load exchange rows from JSON
- record activity in `CODEXLOG_CURRENT.md`

## Testing
- `javac -cp json.jar -d out $(find src -name '*.java')`
- *(failed: `java -cp out:json.jar colog.Main` due to HeadlessException)*

------
https://chatgpt.com/codex/tasks/task_b_6879a2b75aa48321aa81f938a4784d9d