### PR TITLE
Improve ExchangePanel rendering

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -12,3 +12,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507180129][c4000c][FTR] Integrated JSON parser and dynamic row loading
 [2507180151][8b27e81][REF][FTR] Replaced org.json parser with stubbed custom classes
 [2507180609][d6a1da][FTR] Implemented manual ChatGPT JSON parsing
+[2507180712][65e07b][BUG][FTR] Improved ExchangePanel rendering and expand/collapse

--- a/src/colog/ExchangePanel.java
+++ b/src/colog/ExchangePanel.java
@@ -3,26 +3,49 @@ package colog;
 import javax.swing.*;
 import javax.swing.border.LineBorder;
 import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 
 /**
- * A single exchange row with timestamp, summary, tags, and expand icon.
+ * A single exchange row with timestamp, summary, tags, and expandable prompt/response text.
  */
 public class ExchangePanel extends JPanel {
-    private static final int ROW_HEIGHT = 50;
+    private static final int DEFAULT_WIDTH = 600;
 
-    public ExchangePanel(String timestamp, String summary, String tags) {
+    private final String promptText;
+    private final String responseText;
+
+    private final JTextArea promptArea;
+    private final JTextArea responseArea;
+    private final JLabel expandLabel;
+    private final int lineHeight;
+    private boolean expanded = false;
+
+    public ExchangePanel(String timestamp, String prompt, String response, String tags) {
+        this.promptText = prompt == null ? "" : prompt;
+        this.responseText = response == null ? "" : response;
+
         setLayout(new BorderLayout());
         setBorder(new LineBorder(Color.LIGHT_GRAY));
-        setMaximumSize(new Dimension(Integer.MAX_VALUE, ROW_HEIGHT));
-        setPreferredSize(new Dimension(600, ROW_HEIGHT));
+
+        // Create one area up-front to obtain font metrics for row height
+        JTextArea metricsArea = new JTextArea();
+        lineHeight = metricsArea.getFontMetrics(metricsArea.getFont()).getHeight();
 
         JLabel timeLabel = new JLabel(timestamp);
         timeLabel.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
         add(timeLabel, BorderLayout.WEST);
 
-        JLabel summaryLabel = new JLabel("<html>" + summary + "</html>");
-        summaryLabel.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
-        add(summaryLabel, BorderLayout.CENTER);
+        JPanel textPanel = new JPanel();
+        textPanel.setLayout(new BoxLayout(textPanel, BoxLayout.Y_AXIS));
+        textPanel.setOpaque(false);
+
+        promptArea = createArea("");
+        textPanel.add(promptArea);
+        responseArea = createArea(responseText);
+        textPanel.add(responseArea);
+
+        add(textPanel, BorderLayout.CENTER);
 
         JPanel rightPanel = new JPanel();
         rightPanel.setOpaque(false);
@@ -32,10 +55,73 @@ public class ExchangePanel extends JPanel {
         tagsLabel.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
         rightPanel.add(tagsLabel);
 
-        JLabel expandLabel = new JLabel("\u2BC8"); // placeholder icon
+        expandLabel = new JLabel("\u2BC8");
         expandLabel.setBorder(BorderFactory.createEmptyBorder(0, 10, 0, 5));
+        expandLabel.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        expandLabel.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                toggleExpanded();
+            }
+        });
         rightPanel.add(expandLabel);
 
         add(rightPanel, BorderLayout.EAST);
+
+        collapse();
+    }
+
+    private JTextArea createArea(String text) {
+        JTextArea area = new JTextArea(text);
+        area.setLineWrap(true);
+        area.setWrapStyleWord(true);
+        area.setEditable(false);
+        area.setOpaque(false);
+        area.setAlignmentX(LEFT_ALIGNMENT);
+        return area;
+    }
+
+    private String firstLine(String text) {
+        if (text == null) return "";
+        int idx = text.indexOf('\n');
+        return idx >= 0 ? text.substring(0, idx) : text;
+    }
+
+    private int countLines(String text) {
+        if (text == null || text.isEmpty()) return 1;
+        int lines = 1;
+        for (int i = 0; i < text.length(); i++) {
+            if (text.charAt(i) == '\n') lines++;
+        }
+        return lines;
+    }
+
+    private void collapse() {
+        expanded = false;
+        promptArea.setText(firstLine(promptText));
+        responseArea.setVisible(false);
+        setPreferredSize(new Dimension(DEFAULT_WIDTH, lineHeight));
+        setMaximumSize(new Dimension(Integer.MAX_VALUE, lineHeight));
+        revalidate();
+    }
+
+    private void expand() {
+        expanded = true;
+        promptArea.setText(promptText);
+        responseArea.setText(responseText);
+        responseArea.setVisible(true);
+        int lines = countLines(promptText) + countLines(responseText);
+        int height = lineHeight * lines;
+        setPreferredSize(new Dimension(DEFAULT_WIDTH, height));
+        setMaximumSize(new Dimension(Integer.MAX_VALUE, height));
+        revalidate();
+    }
+
+    private void toggleExpanded() {
+        if (expanded) {
+            collapse();
+        } else {
+            expand();
+        }
     }
 }

--- a/src/colog/Main.java
+++ b/src/colog/Main.java
@@ -62,7 +62,11 @@ public class Main {
                 Conversation conv = ConversationLoader.parseConversationFromFile(selected);
                 container.removeAll();
                 for (Exchange ex : conv.exchanges) {
-                    container.add(new ExchangePanel(ex.timestamp, ex.summary, String.join(", ", ex.tags)));
+                    container.add(new ExchangePanel(
+                            ex.timestamp,
+                            ex.prompt,
+                            ex.response,
+                            String.join(", ", ex.tags)));
                 }
                 container.revalidate();
                 container.repaint();


### PR DESCRIPTION
## Summary
- replace JLabel with JTextArea and implement expandable prompt/response text in `ExchangePanel`
- pass full prompt and response to `ExchangePanel`
- update activity log

## Testing
- `javac @sources.txt`
- `java -cp src colog.Main` *(fails: No X11 DISPLAY variable was set)*

------
https://chatgpt.com/codex/tasks/task_b_6879f332d088832193b76fcd5ea9b74e