### PR TITLE
Improve ExchangePanel expand/collapse handling

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -16,3 +16,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507181001][92718e8][FTR] Parsed mapping to build conversation exchanges
 [2507182035][d7103e5][FTR][REF] Finalized message parsing into exchanges
 [2507182050][b15314][FTR][REF] Added toggleable expand/collapse behavior in ExchangePanel
+[2507182159][c08061][FTR][REF] Refined ExchangePanel expand/collapse handling


### PR DESCRIPTION
## Summary
- tweak `ExchangePanel` layout to vertical `BoxLayout`
- use `JTextArea`s for all text with dynamic height
- compute collapsed/expanded height with `FontMetrics`
- keep summary visible when expanded and update arrow icon
- log work in CODEXLOG_CURRENT

## Testing
- `javac @sources.txt`


------
https://chatgpt.com/codex/tasks/task_b_687ac2e8a4d08321bfef31d9e03cb0b4