### PR TITLE
Implement ConversationPanel grouping

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -17,3 +17,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507182035][d7103e5][FTR][REF] Finalized message parsing into exchanges
 [2507182050][b15314][FTR][REF] Added toggleable expand/collapse behavior in ExchangePanel
 [2507182159][c08061][FTR][REF] Refined ExchangePanel expand/collapse handling
+[2507182311][8dff0d][FTR][REF] Grouped exchanges under conversation panels

--- a/src/colog/ConversationPanel.java
+++ b/src/colog/ConversationPanel.java
@@ -1,26 +1,26 @@
 package colog;
 
 import javax.swing.*;
-import javax.swing.border.EmptyBorder;
-import javax.swing.border.LineBorder;
 import java.awt.*;
-import java.util.List;
 
 /**
- * Container for multiple ExchangePanels representing a conversation.
+ * Displays a conversation title followed by its exchange panels.
  */
 public class ConversationPanel extends JPanel {
-    public ConversationPanel(String title, List<ExchangePanel> exchanges) {
+    public ConversationPanel(Conversation conversation) {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-        setBorder(new LineBorder(Color.DARK_GRAY));
-        setAlignmentX(LEFT_ALIGNMENT);
 
-        JLabel titleLabel = new JLabel(title);
-        titleLabel.setBorder(new EmptyBorder(5, 5, 5, 5));
+        JLabel titleLabel = new JLabel(conversation.title);
+        titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD, 16f));
         add(titleLabel);
 
-        for (ExchangePanel ex : exchanges) {
-            add(ex);
+        JSeparator separator = new JSeparator(SwingConstants.HORIZONTAL);
+        add(separator);
+
+        for (Exchange ex : conversation.exchanges) {
+            add(new ExchangePanel(ex));
         }
+
+        setBorder(BorderFactory.createEmptyBorder(10, 0, 20, 0));
     }
 }

--- a/src/colog/ExchangePanel.java
+++ b/src/colog/ExchangePanel.java
@@ -22,6 +22,10 @@ public class ExchangePanel extends JPanel {
     private final JLabel expandLabel;
     private boolean isExpanded = false;
 
+    public ExchangePanel(Exchange ex) {
+        this(ex.timestamp, ex.prompt, ex.response, String.join(", ", ex.tags));
+    }
+
     public ExchangePanel(String timestamp, String prompt, String response, String tags) {
         this.promptText = prompt == null ? "" : prompt;
         this.responseText = response == null ? "" : response;

--- a/src/colog/Main.java
+++ b/src/colog/Main.java
@@ -61,13 +61,7 @@ public class Main {
             try {
                 Conversation conv = ConversationLoader.parseConversationFromFile(selected);
                 container.removeAll();
-                for (Exchange ex : conv.exchanges) {
-                    container.add(new ExchangePanel(
-                            ex.timestamp,
-                            ex.prompt,
-                            ex.response,
-                            String.join(", ", ex.tags)));
-                }
+                container.add(new ConversationPanel(conv));
                 container.revalidate();
                 container.repaint();
                 scrollPane.revalidate();


### PR DESCRIPTION
## Summary
- group exchanges by conversation in the UI
- add constructor for `ExchangePanel` that accepts an `Exchange`
- log development work

## Testing
- `javac src/colog/*.java`
- `java -cp src colog.Main` *(fails: java.awt.HeadlessException)*

------
https://chatgpt.com/codex/tasks/task_b_687ad41520ac83218931f85f9042c5eb