### PR TITLE
Preserve expand state and scroll position

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -18,3 +18,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507182050][b15314][FTR][REF] Added toggleable expand/collapse behavior in ExchangePanel
 [2507182159][c08061][FTR][REF] Refined ExchangePanel expand/collapse handling
 [2507182311][8dff0d][FTR][REF] Grouped exchanges under conversation panels
+[2507182317][924969e][FTR][REF] Preserved expand state and scroll position

--- a/src/colog/Exchange.java
+++ b/src/colog/Exchange.java
@@ -9,6 +9,7 @@ public class Exchange {
     public String response;
     public List<String> tags = new ArrayList<>();
     public String summary;
+    public boolean isExpanded = false;
 
     public Exchange(String timestamp, String prompt, String response) {
         this.timestamp = timestamp;

--- a/src/colog/ExchangePanel.java
+++ b/src/colog/ExchangePanel.java
@@ -21,14 +21,19 @@ public class ExchangePanel extends JPanel {
     private final JTextArea responseArea;
     private final JLabel expandLabel;
     private boolean isExpanded = false;
+    private Exchange exchange;
 
     public ExchangePanel(Exchange ex) {
         this(ex.timestamp, ex.prompt, ex.response, String.join(", ", ex.tags));
+        this.exchange = ex;
+        this.isExpanded = ex.isExpanded;
+        updateLayout();
     }
 
-    public ExchangePanel(String timestamp, String prompt, String response, String tags) {
+    private ExchangePanel(String timestamp, String prompt, String response, String tags) {
         this.promptText = prompt == null ? "" : prompt;
         this.responseText = response == null ? "" : response;
+        this.exchange = null;
 
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         setBorder(new LineBorder(Color.LIGHT_GRAY));
@@ -124,8 +129,19 @@ public class ExchangePanel extends JPanel {
     }
 
     private void toggleExpanded() {
+        JScrollPane pane = (JScrollPane) SwingUtilities.getAncestorOfClass(JScrollPane.class, this);
+        JScrollBar bar = pane == null ? null : pane.getVerticalScrollBar();
+        int val = bar == null ? 0 : bar.getValue();
+
         isExpanded = !isExpanded;
+        if (exchange != null) {
+            exchange.isExpanded = isExpanded;
+        }
         updateHeights();
         updateLayout();
+
+        if (bar != null) {
+            bar.setValue(val);
+        }
     }
 }

--- a/src/colog/Main.java
+++ b/src/colog/Main.java
@@ -60,11 +60,14 @@ public class Main {
             }
             try {
                 Conversation conv = ConversationLoader.parseConversationFromFile(selected);
+                JScrollBar bar = scrollPane.getVerticalScrollBar();
+                int val = bar.getValue();
                 container.removeAll();
                 container.add(new ConversationPanel(conv));
                 container.revalidate();
                 container.repaint();
                 scrollPane.revalidate();
+                bar.setValue(val);
             } catch (IOException ex) {
                 JOptionPane.showMessageDialog(parent, "Error reading file: " + ex.getMessage(),
                         "Read Error", JOptionPane.ERROR_MESSAGE);


### PR DESCRIPTION
## Summary
- track whether an exchange row is expanded
- maintain expanded state when building UI panels
- restore scroll position after refresh operations

## Testing
- `javac -d /tmp/out $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_b_687ad542ec588321824b43c1065ecb75