### PR TITLE
Add summary and tag inference

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -19,3 +19,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507182159][c08061][FTR][REF] Refined ExchangePanel expand/collapse handling
 [2507182311][8dff0d][FTR][REF] Grouped exchanges under conversation panels
 [2507182317][924969e][FTR][REF] Preserved expand state and scroll position
+[2507182325][49d901][FTR][REF] Added auto summary and tag inference

--- a/src/colog/CustomJsonParser.java
+++ b/src/colog/CustomJsonParser.java
@@ -23,6 +23,20 @@ public class CustomJsonParser {
         List<String> children = new ArrayList<>();
     }
 
+    private static List<String> inferTags(String prompt, String response) {
+        List<String> tags = new ArrayList<>();
+        String text = (prompt + " " + response).toLowerCase();
+
+        if (text.contains("bug") || text.contains("fix")) tags.add("bug");
+        if (text.contains("ui") || text.contains("layout")) tags.add("ui");
+        if (text.contains("api") || text.contains("request")) tags.add("api");
+        if (text.contains("performance")) tags.add("performance");
+        if (text.contains("refactor")) tags.add("refactor");
+        if (text.contains("firebase")) tags.add("firebase");
+
+        return tags;
+    }
+
     public static Conversation extractConversation(String rawJson) {
         String title = extractTitle(rawJson);
         Conversation conv = new Conversation(title == null ? "Untitled" : title);
@@ -44,7 +58,9 @@ public class CustomJsonParser {
             String ts = msg.createTime > 0
                     ? TIME_FMT.format(Instant.ofEpochSecond(msg.createTime))
                     : "";
-            conv.exchanges.add(new Exchange(ts, prompt, response));
+            Exchange ex = new Exchange(ts, prompt, response);
+            ex.tags = inferTags(prompt, response);
+            conv.exchanges.add(ex);
         }
 
         return conv;

--- a/src/colog/Exchange.java
+++ b/src/colog/Exchange.java
@@ -18,9 +18,15 @@ public class Exchange {
         this.summary = generateSummary(prompt, response);
     }
 
-    private String generateSummary(String prompt, String response) {
-        if (prompt == null || prompt.isBlank()) return "No summary";
-        int end = prompt.indexOf('\n');
-        return end > 0 ? prompt.substring(0, end).trim() : prompt.trim();
+    private static String generateSummary(String prompt, String response) {
+        if (prompt != null && !prompt.isBlank()) {
+            String cleaned = prompt.strip().replaceAll("[\\r\\n]+", " ");
+            return cleaned.length() > 200 ? cleaned.substring(0, 200) + "…" : cleaned;
+        }
+        if (response != null && !response.isBlank()) {
+            String cleaned = response.strip().replaceAll("[\\r\\n]+", " ");
+            return cleaned.length() > 200 ? cleaned.substring(0, 200) + "…" : cleaned;
+        }
+        return "(no content)";
     }
 }


### PR DESCRIPTION
## Summary
- generate summaries from prompts or responses up to 200 chars
- infer basic tags during JSON parsing
- attach inferred tags to exchanges
- log feature addition

## Testing
- `javac @sources.txt`


------
https://chatgpt.com/codex/tasks/task_b_687ad752abac8321b754ee168c2f7de5