### PR TITLE
Support multi-conversation JSON files

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -20,3 +20,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507182311][8dff0d][FTR][REF] Grouped exchanges under conversation panels
 [2507182317][924969e][FTR][REF] Preserved expand state and scroll position
 [2507182325][49d901][FTR][REF] Added auto summary and tag inference
+[2507190051][e0b826][FTR][REF] Added support for multi-conversation JSON

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Colog V3 fixes this by turning your chat history into a **project memory system*
 
 ## ✨ Features
 
-- **ChatGPT JSON Importer**  
-  Parse exported `.json` files and convert them into structured `Exchange` objects (prompt + response).
+- **ChatGPT JSON Importer**
+  Parse exported `.json` files and convert them into structured conversations and exchanges. Supports files containing multiple conversations.
 
 - **Conversation & Project Grouping**  
   Organize exchanges by conversation and associate conversations with larger projects.

--- a/src/colog/ConversationLoader.java
+++ b/src/colog/ConversationLoader.java
@@ -4,10 +4,51 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ConversationLoader {
-    public static Conversation parseConversationFromFile(File file) throws IOException {
-        String json = Files.readString(file.toPath(), StandardCharsets.UTF_8);
-        return CustomJsonParser.extractConversation(json);
+    public static List<Conversation> parseConversationsFromFile(File file) throws IOException {
+        String rawJson = Files.readString(file.toPath(), StandardCharsets.UTF_8);
+        if (rawJson.trim().startsWith("[")) {
+            List<String> blocks = extractJsonObjectsFromArray(rawJson);
+            List<Conversation> all = new ArrayList<>();
+            for (String block : blocks) {
+                all.add(CustomJsonParser.extractConversation(block));
+            }
+            return all;
+        } else {
+            return List.of(CustomJsonParser.extractConversation(rawJson));
+        }
+    }
+
+    private static List<String> extractJsonObjectsFromArray(String json) {
+        List<String> blocks = new ArrayList<>();
+        boolean inString = false;
+        boolean escape = false;
+        int depth = 0;
+        int start = -1;
+        for (int i = 0; i < json.length(); i++) {
+            char c = json.charAt(i);
+            if (escape) {
+                escape = false;
+            } else if (c == '\\') {
+                escape = true;
+            } else if (c == '"') {
+                inString = !inString;
+            } else if (!inString) {
+                if (c == '{') {
+                    if (depth == 0) start = i;
+                    depth++;
+                } else if (c == '}') {
+                    depth--;
+                    if (depth == 0 && start >= 0) {
+                        blocks.add(json.substring(start, i + 1));
+                        start = -1;
+                    }
+                }
+            }
+        }
+        return blocks;
     }
 }

--- a/src/colog/Main.java
+++ b/src/colog/Main.java
@@ -59,11 +59,13 @@ public class Main {
                 return;
             }
             try {
-                Conversation conv = ConversationLoader.parseConversationFromFile(selected);
+                java.util.List<Conversation> conversations = ConversationLoader.parseConversationsFromFile(selected);
                 JScrollBar bar = scrollPane.getVerticalScrollBar();
                 int val = bar.getValue();
                 container.removeAll();
-                container.add(new ConversationPanel(conv));
+                for (Conversation c : conversations) {
+                    container.add(new ConversationPanel(c));
+                }
                 container.revalidate();
                 container.repaint();
                 scrollPane.revalidate();


### PR DESCRIPTION
## Summary
- load `.json` files containing either a single conversation or an array of conversations
- display each parsed conversation sequentially in the UI
- document multi-conversation import capability
- log the new feature

## Testing
- `javac $(find src -name "*.java")`

------
https://chatgpt.com/codex/tasks/task_b_687aeb8ba8a48321a658c3a70693c1f2