### PR TITLE
Implement search filtering feature

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -21,3 +21,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507182317][924969e][FTR][REF] Preserved expand state and scroll position
 [2507182325][49d901][FTR][REF] Added auto summary and tag inference
 [2507190051][e0b826][FTR][REF] Added support for multi-conversation JSON
+[2507190152][959b72][FTR][REF] Added search filtering UI and logic

--- a/src/colog/ConversationPanel.java
+++ b/src/colog/ConversationPanel.java
@@ -8,16 +8,20 @@ import java.awt.*;
  */
 public class ConversationPanel extends JPanel {
     public ConversationPanel(Conversation conversation) {
+        this(conversation.title, conversation.exchanges);
+    }
+
+    public ConversationPanel(String title, java.util.List<Exchange> visibleExchanges) {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 
-        JLabel titleLabel = new JLabel(conversation.title);
+        JLabel titleLabel = new JLabel(title);
         titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD, 16f));
         add(titleLabel);
 
         JSeparator separator = new JSeparator(SwingConstants.HORIZONTAL);
         add(separator);
 
-        for (Exchange ex : conversation.exchanges) {
+        for (Exchange ex : visibleExchanges) {
             add(new ExchangePanel(ex));
         }
 


### PR DESCRIPTION
## Summary
- add search bar above scrollable list
- filter exchanges in real time based on prompt, response, summary, or tags
- update ConversationPanel to accept filtered list of exchanges
- update activity log

## Testing
- `javac -d build $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_b_687af9e5fa4483219fa01ec297ad867a