### PR TITLE
Implement tag filtering via clickable labels

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -23,3 +23,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507190051][e0b826][FTR][REF] Added support for multi-conversation JSON
 [2507190152][959b72][FTR][REF] Added search filtering UI and logic
 [2507190200][4d491a][FTR][REF] Added summary sidebar panel with clickable navigation to exchanges
+[2507190211][1ed2b5][FTR][REF] Implemented tag-based filtering with clickable labels

--- a/src/colog/ExchangePanel.java
+++ b/src/colog/ExchangePanel.java
@@ -24,13 +24,13 @@ public class ExchangePanel extends JPanel {
     private Exchange exchange;
 
     public ExchangePanel(Exchange ex) {
-        this(ex.timestamp, ex.prompt, ex.response, String.join(", ", ex.tags));
+        this(ex.timestamp, ex.prompt, ex.response, ex.tags);
         this.exchange = ex;
         this.isExpanded = ex.isExpanded;
         updateLayout();
     }
 
-    private ExchangePanel(String timestamp, String prompt, String response, String tags) {
+    private ExchangePanel(String timestamp, String prompt, String response, java.util.List<String> tagsList) {
         this.promptText = prompt == null ? "" : prompt;
         this.responseText = response == null ? "" : response;
         this.exchange = null;
@@ -59,9 +59,19 @@ public class ExchangePanel extends JPanel {
 
         header.add(Box.createHorizontalGlue());
 
-        JLabel tagsLabel = new JLabel(tags);
-        tagsLabel.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
-        header.add(tagsLabel);
+        for (String tag : tagsList) {
+            JLabel tagLabel = new JLabel("#" + tag);
+            tagLabel.setForeground(Color.BLUE.darker());
+            tagLabel.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
+            tagLabel.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+            tagLabel.addMouseListener(new MouseAdapter() {
+                @Override
+                public void mouseClicked(MouseEvent e) {
+                    TagFilter.setActiveTag(tag);
+                }
+            });
+            header.add(tagLabel);
+        }
         header.setAlignmentX(LEFT_ALIGNMENT);
         add(header);
 

--- a/src/colog/TagFilter.java
+++ b/src/colog/TagFilter.java
@@ -1,0 +1,28 @@
+package colog;
+
+public class TagFilter {
+    private static String activeTag = null;
+    private static Runnable onFilterChanged;
+
+    public static void setFilterListener(Runnable listener) {
+        onFilterChanged = listener;
+    }
+
+    public static void setActiveTag(String tag) {
+        activeTag = tag;
+        if (onFilterChanged != null) onFilterChanged.run();
+    }
+
+    public static String getActiveTag() {
+        return activeTag;
+    }
+
+    public static boolean matches(Exchange ex) {
+        return activeTag == null || ex.tags.contains(activeTag);
+    }
+
+    public static void clear() {
+        activeTag = null;
+        if (onFilterChanged != null) onFilterChanged.run();
+    }
+}


### PR DESCRIPTION
## Summary
- make exchange tags clickable to set an active filter
- add TagFilter singleton to manage active tag
- hook filter logic into Main and provide a "Clear Tag Filter" button
- update filtering logic to combine search query and active tag

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_b_687afe490b4c8321a5faf14125bc65a8