### PR TITLE
Fix ExchangePanel height handling

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -28,3 +28,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507190526][54acc15][BUG][FTR] Fixed exchange parsing and search filter logic
 
 [2507190651][abafd1e][BUG][FTR] Restored JSplitPane layout after load and resize
+[2507190807][b45b16][BUG][REF] Fixed text clipping and collapsed row height in ExchangePanel

--- a/TASKS.md
+++ b/TASKS.md
@@ -5,6 +5,7 @@
 
 ## 🚧 In Progress
 - None
+- Fix text clipping and ensure correct heights for collapsed and expanded ExchangePanel states
 
 ## 🔜 Upcoming
 - Set up initial project structure and documentation

--- a/src/colog/ExchangePanel.java
+++ b/src/colog/ExchangePanel.java
@@ -10,8 +10,6 @@ import java.awt.event.MouseEvent;
  * A single exchange row with timestamp, summary, tags, and expandable prompt/response text.
  */
 public class ExchangePanel extends JPanel {
-    private static final int DEFAULT_WIDTH = 600;
-    private static final int PADDING = 10;
 
     private final String promptText;
     private final String responseText;
@@ -76,6 +74,8 @@ public class ExchangePanel extends JPanel {
         add(header);
 
         summaryArea = createArea(firstLine(promptText));
+        summaryArea.setRows(1);
+        summaryArea.setMaximumSize(new Dimension(Integer.MAX_VALUE, summaryArea.getPreferredSize().height));
         summaryArea.setAlignmentX(LEFT_ALIGNMENT);
         add(summaryArea);
 
@@ -89,7 +89,6 @@ public class ExchangePanel extends JPanel {
         responseArea.setAlignmentX(LEFT_ALIGNMENT);
         add(responseArea);
 
-        updateHeights();
         updateLayout();
     }
 
@@ -97,8 +96,10 @@ public class ExchangePanel extends JPanel {
         JTextArea area = new JTextArea(text);
         area.setLineWrap(true);
         area.setWrapStyleWord(true);
-        area.setEditable(false);
         area.setOpaque(false);
+        area.setEditable(false);
+        area.setFocusable(false);
+        area.setBorder(null);
         area.setAlignmentX(LEFT_ALIGNMENT);
         return area;
     }
@@ -109,31 +110,12 @@ public class ExchangePanel extends JPanel {
         return idx >= 0 ? text.substring(0, idx) : text;
     }
 
-    private int getAreaHeight(JTextArea area) {
-        FontMetrics fm = area.getFontMetrics(area.getFont());
-        area.setSize(DEFAULT_WIDTH, Short.MAX_VALUE);
-        int lines = area.getLineCount();
-        if (lines == 0) lines = 1;
-        return fm.getHeight() * lines;
-    }
-
-    private int collapsedHeight;
-    private int expandedHeight;
-
-    private void updateHeights() {
-        collapsedHeight = getAreaHeight(summaryArea) + PADDING;
-        expandedHeight = getAreaHeight(summaryArea) + getAreaHeight(promptArea) + getAreaHeight(responseArea) + PADDING;
-    }
-
     private void updateLayout() {
         summaryArea.setVisible(true);
         promptArea.setVisible(isExpanded);
         responseArea.setVisible(isExpanded);
         expandLabel.setText(isExpanded ? "\u2BC6" : "\u2BC8");
 
-        int height = isExpanded ? expandedHeight : collapsedHeight;
-        setPreferredSize(new Dimension(DEFAULT_WIDTH, height));
-        setMaximumSize(new Dimension(Integer.MAX_VALUE, height));
         revalidate();
         repaint();
     }
@@ -147,7 +129,6 @@ public class ExchangePanel extends JPanel {
         if (exchange != null) {
             exchange.isExpanded = isExpanded;
         }
-        updateHeights();
         updateLayout();
 
         if (bar != null) {


### PR DESCRIPTION
## Summary
- adjust `ExchangePanel` to use natural sizing for text areas
- show single-line summary when collapsed
- note bug fix in tasks
- log fix

## Testing
- `javac src/colog/*.java`

------
https://chatgpt.com/codex/tasks/task_b_687b51cec9548321bff30d0cb1cf0a51