### PR TITLE
Fix substring bounds in JSON parser

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -31,3 +31,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507190807][b45b16][BUG][REF] Fixed text clipping and collapsed row height in ExchangePanel
 [2507190811][f4e8146][FTR] Improved tag label interactivity
 [2507190916][688e17][FTR][REF] Clarified search and tag filter UI
+[2507192036][b3ff80][BUG][ERR] Fixed off-by-one substring bounds in JSON parser

--- a/src/colog/ConversationLoader.java
+++ b/src/colog/ConversationLoader.java
@@ -43,7 +43,11 @@ public class ConversationLoader {
                 } else if (c == '}') {
                     depth--;
                     if (depth == 0 && start >= 0) {
-                        blocks.add(json.substring(start, i + 1));
+                        int safeEnd = Math.min(i + 1, json.length());
+                        if (i + 1 > json.length()) {
+                            System.out.println("[WARN] Trimming JSON end offset to avoid overflow.");
+                        }
+                        blocks.add(json.substring(start, safeEnd));
                         start = -1;
                     }
                 }

--- a/src/colog/CustomJsonParser.java
+++ b/src/colog/CustomJsonParser.java
@@ -91,7 +91,11 @@ public class CustomJsonParser {
             if (c == '}') depth--;
             if (depth == 0) break;
         }
-        return json.substring(braceStart, end + 1);
+        int safeEnd = Math.min(end + 1, json.length());
+        if (end + 1 > json.length()) {
+            System.out.println("[WARN] Trimming JSON end offset to avoid overflow.");
+        }
+        return json.substring(braceStart, safeEnd);
     }
 
     private static List<String> extractMessageBlocks(String mappingJson) {
@@ -122,7 +126,11 @@ public class CustomJsonParser {
                     }
                 } else if (c == '}') {
                     if (depth == 2 && start >= 0) {
-                        blocks.add(mappingJson.substring(start, i + 1));
+                        int safeEnd = Math.min(i + 1, mappingJson.length());
+                        if (i + 1 > mappingJson.length()) {
+                            System.out.println("[WARN] Trimming JSON end offset to avoid overflow.");
+                        }
+                        blocks.add(mappingJson.substring(start, safeEnd));
                         start = -1;
                     }
                     depth--;


### PR DESCRIPTION
## Summary
- avoid `StringIndexOutOfBoundsException` when parsing large files
- log when end offsets are trimmed
- record log entry for the bug fix

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_b_687c0176f6ac8321899292a2055004b6