### PR TITLE
Update right panel on conversation click

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -34,3 +34,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507192036][b3ff80][BUG][ERR] Fixed off-by-one substring bounds in JSON parser
 [2507192110][3e9b29][FTR][REF] Refactored JSON loader to stream conversations via BufferedReader
 [2507192136][80764b8][FTR][REF] Scrollable conversation list sidebar
+[2507192149][a0e80f][FTR][REF] Updated conversation selection logic and scroll speed

--- a/src/colog/ConversationRowPanel.java
+++ b/src/colog/ConversationRowPanel.java
@@ -14,26 +14,22 @@ import java.util.Set;
  * Compact row representing a conversation in the sidebar.
  */
 public class ConversationRowPanel extends JPanel {
-    public interface RowClickListener {
-        void onRowClicked(int index);
-    }
+    // Simple row click handling now directly notifies Main
 
     private static final DateTimeFormatter IN_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final DateTimeFormatter OUT_FMT = DateTimeFormatter.ofPattern("d/MM/yy H:mm:ss");
 
     private final int index;
     private final Conversation conversation;
-    private final RowClickListener listener;
 
     private final JLabel idLabel;
     private final JLabel timeLabel;
     private final JLabel titleLabel;
     private final JLabel tagLabel;
 
-    public ConversationRowPanel(int index, Conversation conversation, RowClickListener listener) {
+    public ConversationRowPanel(int index, Conversation conversation) {
         this.index = index;
         this.conversation = conversation;
-        this.listener = listener;
 
         setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
         setOpaque(true);
@@ -57,7 +53,7 @@ public class ConversationRowPanel extends JPanel {
         addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
-                if (listener != null) listener.onRowClicked(index - 1);
+                Main.selectConversation(conversation);
             }
         });
     }

--- a/src/colog/Main.java
+++ b/src/colog/Main.java
@@ -58,6 +58,7 @@ public class Main {
         container.setLayout(new BoxLayout(container, BoxLayout.Y_AXIS));
 
         scrollPane = new JScrollPane(container);
+        scrollPane.getVerticalScrollBar().setUnitIncrement(24);
 
         conversationListPanel = new JPanel();
         conversationListPanel.setLayout(new BoxLayout(conversationListPanel, BoxLayout.Y_AXIS));
@@ -203,7 +204,7 @@ public class Main {
         conversationRows.clear();
         for (int i = 0; i < visibleConversations.size(); i++) {
             Conversation c = visibleConversations.get(i);
-            ConversationRowPanel row = new ConversationRowPanel(i + 1, c, idx -> selectConversation(idx));
+            ConversationRowPanel row = new ConversationRowPanel(i + 1, c);
             conversationRows.add(row);
             conversationListPanel.add(row);
         }
@@ -211,13 +212,18 @@ public class Main {
 
     private static void selectConversation(int index) {
         if (index < 0 || index >= visibleConversations.size()) return;
-        selectedConversationIndex = index;
+        selectConversation(visibleConversations.get(index));
+    }
+
+    public static void selectConversation(Conversation c) {
+        if (c == null) return;
+        selectedConversationIndex = visibleConversations.indexOf(c);
         container.removeAll();
-        container.add(new ConversationPanel(visibleConversations.get(index)));
+        container.add(new ConversationPanel(c));
         container.revalidate();
         container.repaint();
         for (int i = 0; i < conversationRows.size(); i++) {
-            conversationRows.get(i).setSelected(i == index);
+            conversationRows.get(i).setSelected(visibleConversations.get(i) == c);
         }
     }
 


### PR DESCRIPTION
## Summary
- make conversation rows directly select conversations
- add scroll speed adjustment
- provide `selectConversation(Conversation)` API
- log update

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_b_687c124aed008321bdb86e4e2f461571