### PR TITLE
Enhance ExchangePanel summaries

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -36,3 +36,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507192136][80764b8][FTR][REF] Scrollable conversation list sidebar
 [2507192149][a0e80f][FTR][REF] Updated conversation selection logic and scroll speed
 [2507192203][ae1d0d][FTR][REF] Formatted ExchangePanel prompt and response sections
+[2507192226][44e1493][FTR][REF] Added summary preview labels in ExchangePanel

--- a/src/colog/ExchangePanel.java
+++ b/src/colog/ExchangePanel.java
@@ -143,10 +143,11 @@ public class ExchangePanel extends JPanel {
         label.setForeground(fg);
         panel.add(label);
 
-        JLabel summary = new JLabel("Summary: " + firstChars(text, 80));
-        summary.setFont(summary.getFont().deriveFont(summary.getFont().getSize2D() - 2f));
-        summary.setForeground(fg);
-        panel.add(summary);
+        JLabel summaryLabel = new JLabel("Summary: " + summarize(text));
+        summaryLabel.setFont(summaryLabel.getFont().deriveFont(Font.ITALIC, 11f));
+        summaryLabel.setForeground(fg);
+        summaryLabel.setMaximumSize(new Dimension(Integer.MAX_VALUE, summaryLabel.getPreferredSize().height));
+        panel.add(summaryLabel);
 
         panel.add(new JSeparator(SwingConstants.HORIZONTAL));
 
@@ -156,10 +157,11 @@ public class ExchangePanel extends JPanel {
         return panel;
     }
 
-    private static String firstChars(String text, int len) {
+    private static String summarize(String text) {
         if (text == null) return "";
-        text = text.replace("\n", " ").replace("\\n", " ");
-        return text.length() > len ? text.substring(0, len) : text;
+        String summary = text.replaceAll("\\s+", " ").strip();
+        if (summary.length() > 80) summary = summary.substring(0, 80) + "…";
+        return summary;
     }
 
     private String firstLine(String text) {


### PR DESCRIPTION
## Summary
- show short summary line for prompt and response sections
- add helper method to build summaries
- update log

## Testing
- `javac -d out $(find src -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_b_687c1af6d1c88321adb560682e2ab944