### PR TITLE
Indent ExchangePanel response block

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -37,3 +37,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507192149][a0e80f][FTR][REF] Updated conversation selection logic and scroll speed
 [2507192203][ae1d0d][FTR][REF] Formatted ExchangePanel prompt and response sections
 [2507192226][44e1493][FTR][REF] Added summary preview labels in ExchangePanel
+[2507192237][33686a5][FTR][REF] Indented response sections with wrapper panel

--- a/src/colog/ExchangePanel.java
+++ b/src/colog/ExchangePanel.java
@@ -136,23 +136,30 @@ public class ExchangePanel extends JPanel {
         panel.setBackground(bg);
         panel.setOpaque(true);
         panel.setAlignmentX(LEFT_ALIGNMENT);
-        panel.setBorder(new EmptyBorder(4, indent ? 12 : 4, 4, 4));
+        panel.setBorder(new EmptyBorder(4, 4, 4, 4));
+
+        JPanel wrapper = new JPanel();
+        wrapper.setLayout(new BoxLayout(wrapper, BoxLayout.Y_AXIS));
+        wrapper.setBorder(BorderFactory.createEmptyBorder(0, indent ? 20 : 0, 0, 0));
+        wrapper.setOpaque(false);
 
         JLabel label = new JLabel(labelText);
         label.setFont(label.getFont().deriveFont(Font.BOLD));
         label.setForeground(fg);
-        panel.add(label);
+        wrapper.add(label);
 
         JLabel summaryLabel = new JLabel("Summary: " + summarize(text));
         summaryLabel.setFont(summaryLabel.getFont().deriveFont(Font.ITALIC, 11f));
         summaryLabel.setForeground(fg);
         summaryLabel.setMaximumSize(new Dimension(Integer.MAX_VALUE, summaryLabel.getPreferredSize().height));
-        panel.add(summaryLabel);
+        wrapper.add(summaryLabel);
 
-        panel.add(new JSeparator(SwingConstants.HORIZONTAL));
+        wrapper.add(new JSeparator(SwingConstants.HORIZONTAL));
 
         area.setForeground(fg);
-        panel.add(area);
+        wrapper.add(area);
+
+        panel.add(wrapper);
 
         return panel;
     }


### PR DESCRIPTION
## Summary
- add wrapper panel for response section to indent content
- update log with new change

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_b_687c1dbe7c088321bbd228fd953fc02e