### PR TITLE
Fix scroll speed for conversation sidebar

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -38,3 +38,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507192203][ae1d0d][FTR][REF] Formatted ExchangePanel prompt and response sections
 [2507192226][44e1493][FTR][REF] Added summary preview labels in ExchangePanel
 [2507192237][33686a5][FTR][REF] Indented response sections with wrapper panel
+[2507192254][ac94830][FTR][REF] Matched scroll speed for left panel

--- a/src/colog/Main.java
+++ b/src/colog/Main.java
@@ -63,6 +63,7 @@ public class Main {
         conversationListPanel = new JPanel();
         conversationListPanel.setLayout(new BoxLayout(conversationListPanel, BoxLayout.Y_AXIS));
         conversationScrollPane = new JScrollPane(conversationListPanel);
+        conversationScrollPane.getVerticalScrollBar().setUnitIncrement(24);
 
         JPanel searchPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
         searchPanel.add(new JLabel("Search prompt/response:"));


### PR DESCRIPTION
## Summary
- align scroll speed for conversation list with exchange panel

## Testing
- `./gradlew test` *(fails: No such file)*

------
https://chatgpt.com/codex/tasks/task_b_687c220273548321abb52f0dda277b04