### PR TITLE
Show exchange count in conversation list

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -39,3 +39,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507192226][44e1493][FTR][REF] Added summary preview labels in ExchangePanel
 [2507192237][33686a5][FTR][REF] Indented response sections with wrapper panel
 [2507192254][ac94830][FTR][REF] Matched scroll speed for left panel
+[2507192301][e659dd][FTR][REF] Show conversation exchange counts

--- a/src/colog/ConversationRowPanel.java
+++ b/src/colog/ConversationRowPanel.java
@@ -24,6 +24,7 @@ public class ConversationRowPanel extends JPanel {
 
     private final JLabel idLabel;
     private final JLabel timeLabel;
+    private final JLabel countLabel;
     private final JLabel titleLabel;
     private final JLabel tagLabel;
 
@@ -37,12 +38,14 @@ public class ConversationRowPanel extends JPanel {
         Font font = getFont();
         int fontHeight = getFontMetrics(font).getHeight();
 
-        idLabel = createLabel("#" + index, 40, SwingConstants.LEFT, fontHeight);
+        idLabel = createLabel("#" + index, 30, SwingConstants.LEFT, fontHeight);
+        countLabel = createLabel("\u00D7" + conversation.exchanges.size(), 40, SwingConstants.RIGHT, fontHeight);
         timeLabel = createLabel(formatTimestamp(conversation), 110, SwingConstants.LEFT, fontHeight);
         titleLabel = createLabel(conversation.title, 240, SwingConstants.LEFT, fontHeight);
         tagLabel = createLabel(buildTagSummary(conversation), 100, SwingConstants.RIGHT, fontHeight);
 
         add(idLabel);
+        add(countLabel);
         add(timeLabel);
         add(titleLabel);
         add(Box.createHorizontalGlue());


### PR DESCRIPTION
## Summary
- show number of exchanges for each conversation row
- log feature addition

## Testing
- `javac -d out $(find src -name '*.java') && echo "Compiled" && rm -rf out`


------
https://chatgpt.com/codex/tasks/task_b_687c235efda483218a2e77522b763fc3