### PR TITLE
Implement dark theme

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -40,3 +40,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507192237][33686a5][FTR][REF] Indented response sections with wrapper panel
 [2507192254][ac94830][FTR][REF] Matched scroll speed for left panel
 [2507192301][e659dd][FTR][REF] Show conversation exchange counts
+[2507192318][9d93635][FTR][REF] Applied dark theme styling

--- a/src/colog/ConversationRowPanel.java
+++ b/src/colog/ConversationRowPanel.java
@@ -2,6 +2,7 @@ package colog;
 
 import javax.swing.*;
 import java.awt.*;
+import static colog.Theme.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.time.LocalDateTime;
@@ -34,6 +35,7 @@ public class ConversationRowPanel extends JPanel {
 
         setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
         setOpaque(true);
+        setBackground(DARK_BG);
 
         Font font = getFont();
         int fontHeight = getFontMetrics(font).getHeight();
@@ -68,6 +70,9 @@ public class ConversationRowPanel extends JPanel {
         l.setPreferredSize(d);
         l.setMaximumSize(d);
         l.setMinimumSize(d);
+        l.setForeground(LIGHT_TEXT);
+        l.setBackground(DARK_BG);
+        l.setOpaque(true);
         return l;
     }
 
@@ -95,6 +100,6 @@ public class ConversationRowPanel extends JPanel {
     }
 
     public void setSelected(boolean selected) {
-        setBackground(selected ? new Color(220, 220, 250) : null);
+        setBackground(selected ? new Color(50, 50, 80) : DARK_BG);
     }
 }

--- a/src/colog/ExchangePanel.java
+++ b/src/colog/ExchangePanel.java
@@ -7,6 +7,8 @@ import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 
+import static colog.Theme.*;
+
 /**
  * A single exchange row with timestamp, summary, tags, and expandable prompt/response text.
  */
@@ -37,7 +39,8 @@ public class ExchangePanel extends JPanel {
         this.exchange = null;
 
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-        setBorder(new LineBorder(Color.LIGHT_GRAY));
+        setBackground(DARK_BG);
+        setBorder(new LineBorder(LIGHT_TEXT));
 
         JPanel header = new JPanel();
         header.setLayout(new BoxLayout(header, BoxLayout.X_AXIS));
@@ -56,6 +59,8 @@ public class ExchangePanel extends JPanel {
 
         JLabel timeLabel = new JLabel(timestamp);
         timeLabel.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
+        timeLabel.setForeground(LIGHT_TEXT);
+        expandLabel.setForeground(LIGHT_TEXT);
         header.add(timeLabel);
 
         header.add(Box.createHorizontalGlue());
@@ -66,6 +71,8 @@ public class ExchangePanel extends JPanel {
         summaryArea.setRows(1);
         summaryArea.setMaximumSize(new Dimension(Integer.MAX_VALUE, summaryArea.getPreferredSize().height));
         summaryArea.setAlignmentX(LEFT_ALIGNMENT);
+        summaryArea.setBackground(DARK_BG);
+        summaryArea.setForeground(LIGHT_TEXT);
         add(summaryArea);
 
         add(Box.createVerticalStrut(4));
@@ -73,8 +80,8 @@ public class ExchangePanel extends JPanel {
         promptArea = createArea(promptText);
         responseArea = createArea(responseText);
 
-        promptSection = buildSection("Prompt", promptText, promptArea, new Color(230, 230, 230), Color.BLACK, false);
-        responseSection = buildSection("Response", responseText, responseArea, new Color(60, 60, 60), Color.WHITE, true);
+        promptSection = buildSection("Prompt", promptText, promptArea, PROMPT_BG, LIGHT_TEXT, false);
+        responseSection = buildSection("Response", responseText, responseArea, RESPONSE_BG, LIGHT_TEXT, true);
 
         promptSection.setVisible(false);
         responseSection.setVisible(false);
@@ -88,7 +95,10 @@ public class ExchangePanel extends JPanel {
         for (String tag : tagsList) {
             final String t = tag;
             JLabel tagLabel = new JLabel("#" + tag);
-            tagLabel.setForeground(new Color(30, 30, 200));
+            tagLabel.setForeground(LIGHT_TEXT);
+            tagLabel.setBackground(TAG_BG);
+            tagLabel.setOpaque(true);
+            tagLabel.setBorder(new EmptyBorder(0, 4, 0, 4));
             tagLabel.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
             tagLabel.setToolTipText("Click to filter by #" + tag);
             tagLabel.addMouseListener(new MouseAdapter() {
@@ -121,7 +131,9 @@ public class ExchangePanel extends JPanel {
         JTextArea area = new JTextArea(text);
         area.setLineWrap(true);
         area.setWrapStyleWord(true);
-        area.setOpaque(false);
+        area.setOpaque(true);
+        area.setBackground(DARK_BG);
+        area.setForeground(LIGHT_TEXT);
         area.setEditable(false);
         area.setFocusable(false);
         area.setBorder(null);
@@ -146,17 +158,22 @@ public class ExchangePanel extends JPanel {
         JLabel label = new JLabel(labelText);
         label.setFont(label.getFont().deriveFont(Font.BOLD));
         label.setForeground(fg);
+        label.setBackground(bg);
+        label.setOpaque(true);
         wrapper.add(label);
 
         JLabel summaryLabel = new JLabel("Summary: " + summarize(text));
         summaryLabel.setFont(summaryLabel.getFont().deriveFont(Font.ITALIC, 11f));
         summaryLabel.setForeground(fg);
+        summaryLabel.setBackground(bg);
+        summaryLabel.setOpaque(true);
         summaryLabel.setMaximumSize(new Dimension(Integer.MAX_VALUE, summaryLabel.getPreferredSize().height));
         wrapper.add(summaryLabel);
 
         wrapper.add(new JSeparator(SwingConstants.HORIZONTAL));
 
         area.setForeground(fg);
+        area.setBackground(bg);
         wrapper.add(area);
 
         panel.add(wrapper);

--- a/src/colog/Main.java
+++ b/src/colog/Main.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import colog.TagFilter;
 import colog.ConversationRowPanel;
+import static colog.Theme.*;
 
 
 public class Main {
@@ -39,16 +40,25 @@ public class Main {
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setSize(800, 600);
         frame.setResizable(true);
+        frame.getContentPane().setBackground(DARK_BG);
 
         JMenuBar menuBar = new JMenuBar();
+        menuBar.setBackground(DARK_BG);
+        menuBar.setForeground(LIGHT_TEXT);
         JMenu fileMenu = new JMenu("File");
+        fileMenu.setBackground(DARK_BG);
+        fileMenu.setForeground(LIGHT_TEXT);
 
         JMenuItem openItem = new JMenuItem("Open");
         openItem.addActionListener(e -> handleOpen(frame));
+        openItem.setBackground(DARK_BG);
+        openItem.setForeground(LIGHT_TEXT);
         fileMenu.add(openItem);
 
         JMenuItem exitItem = new JMenuItem("Exit");
         exitItem.addActionListener(e -> System.exit(0));
+        exitItem.setBackground(DARK_BG);
+        exitItem.setForeground(LIGHT_TEXT);
         fileMenu.add(exitItem);
 
         menuBar.add(fileMenu);
@@ -56,23 +66,38 @@ public class Main {
 
         container = new JPanel();
         container.setLayout(new BoxLayout(container, BoxLayout.Y_AXIS));
+        container.setBackground(DARK_BG);
 
         scrollPane = new JScrollPane(container);
         scrollPane.getVerticalScrollBar().setUnitIncrement(24);
+        scrollPane.setBorder(BorderFactory.createEmptyBorder());
+        scrollPane.getViewport().setBackground(DARK_BG);
 
         conversationListPanel = new JPanel();
         conversationListPanel.setLayout(new BoxLayout(conversationListPanel, BoxLayout.Y_AXIS));
+        conversationListPanel.setBackground(DARK_BG);
         conversationScrollPane = new JScrollPane(conversationListPanel);
         conversationScrollPane.getVerticalScrollBar().setUnitIncrement(24);
+        conversationScrollPane.setBorder(BorderFactory.createEmptyBorder());
+        conversationScrollPane.getViewport().setBackground(DARK_BG);
 
         JPanel searchPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
-        searchPanel.add(new JLabel("Search prompt/response:"));
+        searchPanel.setBackground(DARK_BG);
+        JLabel searchLabel = new JLabel("Search prompt/response:");
+        searchLabel.setForeground(LIGHT_TEXT);
+        searchPanel.add(searchLabel);
         searchField = new JTextField(40);
+        searchField.setBackground(DARK_BG);
+        searchField.setForeground(LIGHT_TEXT);
+        searchField.setCaretColor(LIGHT_TEXT);
         searchPanel.add(searchField);
         tagFilterStatus = new JLabel();
+        tagFilterStatus.setForeground(LIGHT_TEXT);
         searchPanel.add(tagFilterStatus);
         clearFilter = new JButton("Clear Tag Filter");
         clearFilter.addActionListener(e -> TagFilter.clear());
+        clearFilter.setBackground(DARK_BG);
+        clearFilter.setForeground(LIGHT_TEXT);
         searchPanel.add(clearFilter);
         clearFilter.setEnabled(false);
         searchField.getDocument().addDocumentListener(new DocumentListener() {
@@ -94,6 +119,7 @@ public class Main {
                 conversationScrollPane,
                 scrollPane
         );
+        splitPane.setBackground(DARK_BG);
         splitPane.setDividerLocation(300);
         frame.add(splitPane, BorderLayout.CENTER);
 
@@ -233,7 +259,7 @@ public class Main {
         String tag = TagFilter.getActiveTag();
         if (tag != null) {
             tagFilterStatus.setText("Filtering by tag: #" + tag);
-            tagFilterStatus.setForeground(new Color(100, 50, 0));
+            tagFilterStatus.setForeground(LIGHT_TEXT);
             clearFilter.setEnabled(true);
         } else {
             tagFilterStatus.setText("");

--- a/src/colog/Theme.java
+++ b/src/colog/Theme.java
@@ -1,0 +1,14 @@
+package colog;
+
+import java.awt.Color;
+
+/**
+ * Global color constants for the dark UI theme.
+ */
+public class Theme {
+    public static final Color DARK_BG = new Color(32, 32, 32);
+    public static final Color LIGHT_TEXT = new Color(220, 220, 220);
+    public static final Color PROMPT_BG = new Color(50, 50, 50);
+    public static final Color RESPONSE_BG = new Color(25, 25, 25);
+    public static final Color TAG_BG = new Color(70, 70, 70);
+}


### PR DESCRIPTION
## Summary
- define Theme with global dark colors
- colorize ExchangePanel and ConversationRowPanel
- style search panel, menu bar, and split pane in Main
- document change in CODEXLOG

## Testing
- `javac src/colog/*.java`
- `java colog.Main` *(fails: `java.awt.HeadlessException`)*

------
https://chatgpt.com/codex/tasks/task_b_687c26d6f0b88321bce3cf2b7e394417