### PR TITLE
Fix panel spacing

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -41,3 +41,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507192254][ac94830][FTR][REF] Matched scroll speed for left panel
 [2507192301][e659dd][FTR][REF] Show conversation exchange counts
 [2507192318][9d93635][FTR][REF] Applied dark theme styling
+2507192338[03967f6][BUG][REF] Reduced padding in conversation and exchange panels

--- a/src/colog/ConversationPanel.java
+++ b/src/colog/ConversationPanel.java
@@ -32,7 +32,8 @@ public class ConversationPanel extends JPanel {
             add(ep);
         }
 
-        setBorder(BorderFactory.createEmptyBorder(10, 0, 20, 0));
+        // Remove excess top/bottom padding so exchanges align tightly
+        setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
     }
 
     public java.util.List<ExchangePanel> getExchangePanels() {

--- a/src/colog/ExchangePanel.java
+++ b/src/colog/ExchangePanel.java
@@ -2,7 +2,6 @@ package colog;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
-import javax.swing.border.LineBorder;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -23,6 +22,8 @@ public class ExchangePanel extends JPanel {
     private final JPanel promptSection;
     private final JPanel responseSection;
     private final JLabel expandLabel;
+    private final Component summarySpacing;
+    private final Component sectionSpacing;
     private boolean isExpanded = false;
     private Exchange exchange;
 
@@ -40,7 +41,8 @@ public class ExchangePanel extends JPanel {
 
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         setBackground(DARK_BG);
-        setBorder(new LineBorder(LIGHT_TEXT));
+        // Remove default line border for compact stacked layout
+        setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
 
         JPanel header = new JPanel();
         header.setLayout(new BoxLayout(header, BoxLayout.X_AXIS));
@@ -75,7 +77,8 @@ public class ExchangePanel extends JPanel {
         summaryArea.setForeground(LIGHT_TEXT);
         add(summaryArea);
 
-        add(Box.createVerticalStrut(4));
+        summarySpacing = Box.createVerticalStrut(4);
+        add(summarySpacing);
 
         promptArea = createArea(promptText);
         responseArea = createArea(responseText);
@@ -87,7 +90,8 @@ public class ExchangePanel extends JPanel {
         responseSection.setVisible(false);
 
         add(promptSection);
-        add(Box.createVerticalStrut(8));
+        sectionSpacing = Box.createVerticalStrut(8);
+        add(sectionSpacing);
         add(responseSection);
 
         JPanel tagPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 4, 0));
@@ -198,7 +202,22 @@ public class ExchangePanel extends JPanel {
         summaryArea.setVisible(true);
         promptSection.setVisible(isExpanded);
         responseSection.setVisible(isExpanded);
+        summarySpacing.setVisible(isExpanded);
+        sectionSpacing.setVisible(isExpanded);
         expandLabel.setText(isExpanded ? "\u2BC6" : "\u2BC8");
+
+        FontMetrics fm = getFontMetrics(getFont());
+        int lineHeight = fm.getHeight();
+        if (isExpanded) {
+            setPreferredSize(null);
+            setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+        } else {
+            int lines = 3; // header, summary, tag row
+            int height = lineHeight * lines;
+            Dimension d = new Dimension(Integer.MAX_VALUE, height);
+            setPreferredSize(d);
+            setMaximumSize(d);
+        }
 
         revalidate();
         repaint();


### PR DESCRIPTION
## Summary
- remove default padding in `ConversationPanel`
- collapse ExchangePanel vertical gaps
- size collapsed ExchangePanels using font metrics
- log reduced padding improvement

## Testing
- `javac -d /tmp/out $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_b_687c2ba8c5988321bc33e80c1baf5745