### PR TITLE
Fix expanded ExchangePanel preview

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -42,3 +42,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507192301][e659dd][FTR][REF] Show conversation exchange counts
 [2507192318][9d93635][FTR][REF] Applied dark theme styling
 2507192338[03967f6][BUG][REF] Reduced padding in conversation and exchange panels
+[2507192352][6021439][BUG][REF] Hide preview line when exchange expanded

--- a/src/colog/ExchangePanel.java
+++ b/src/colog/ExchangePanel.java
@@ -199,7 +199,7 @@ public class ExchangePanel extends JPanel {
     }
 
     private void updateLayout() {
-        summaryArea.setVisible(true);
+        summaryArea.setVisible(!isExpanded);
         promptSection.setVisible(isExpanded);
         responseSection.setVisible(isExpanded);
         summarySpacing.setVisible(isExpanded);


### PR DESCRIPTION
## Summary
- hide the preview label when an exchange is expanded so the prompt summary only shows in the prompt section
- update Codex log

## Testing
- `javac @files.txt`

------
https://chatgpt.com/codex/tasks/task_b_687c2f4fc1688321a8d111858d75371c