### PR TITLE
Set startup window size

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -44,3 +44,4 @@ This file records all Codex-generated changes and implementations in this projec
 2507192338[03967f6][BUG][REF] Reduced padding in conversation and exchange panels
 [2507192352][6021439][BUG][REF] Hide preview line when exchange expanded
 [2507200003][799493][FTR][REF] Increased global font size and updated layouts
+[2507200036][f910cb][FTR][REF] Set window to 800x600 and center on startup

--- a/src/colog/Main.java
+++ b/src/colog/Main.java
@@ -146,6 +146,8 @@ public class Main {
         });
 
         frame.pack();
+        frame.setSize(800, 600);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 


### PR DESCRIPTION
## Summary
- ensure the main window starts at 800x600
- center the window on screen
- log the change

## Testing
- `javac $(find src -name '*.java')`
- `java -cp src colog.Main` *(fails: no DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_b_687c39c012e483219c5a94b6c6fdb04f