### PR TITLE
Add conversation list header panel

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -46,3 +46,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507200003][799493][FTR][REF] Increased global font size and updated layouts
 [2507200036][f910cb][FTR][REF] Set window to 800x600 and center on startup
 [2507200049][32d453][FTR][REF] Added separator lines in conversation rows
+[2507200053][55b60c][FTR] Added conversation list header panel

--- a/src/colog/ConversationHeaderRowPanel.java
+++ b/src/colog/ConversationHeaderRowPanel.java
@@ -1,0 +1,63 @@
+package colog;
+
+import javax.swing.*;
+import java.awt.*;
+import static colog.UIStyle.*;
+
+/**
+ * Header row for the conversation list columns.
+ */
+public class ConversationHeaderRowPanel extends JPanel {
+    public ConversationHeaderRowPanel() {
+        Color bg = new Color(40, 40, 40);
+        Color fg = new Color(200, 200, 200);
+        Font font = BASE_FONT.deriveFont(Font.BOLD, BASE_FONT.getSize() - 1f);
+
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setOpaque(true);
+        setBackground(bg);
+
+        FontMetrics fm = getFontMetrics(font);
+        int fontHeight = fm.getHeight();
+
+        JPanel row = new JPanel();
+        row.setLayout(new BoxLayout(row, BoxLayout.X_AXIS));
+        row.setOpaque(true);
+        row.setBackground(bg);
+
+        row.add(createLabel("#", 30, SwingConstants.LEFT, fontHeight, font, fg, bg));
+        row.add(createVLine(fontHeight));
+        row.add(createLabel("Ex", 40, SwingConstants.RIGHT, fontHeight, font, fg, bg));
+        row.add(createVLine(fontHeight));
+        row.add(createLabel("Date/Time", 110, SwingConstants.LEFT, fontHeight, font, fg, bg));
+        row.add(createVLine(fontHeight));
+        row.add(createLabel("Title", 240, SwingConstants.LEFT, fontHeight, font, fg, bg));
+        row.add(createVLine(fontHeight));
+        row.add(Box.createHorizontalGlue());
+
+        row.setPreferredSize(new Dimension(Short.MAX_VALUE, fontHeight));
+        add(row);
+        setPreferredSize(new Dimension(Short.MAX_VALUE, fontHeight + 1));
+    }
+
+    private JLabel createLabel(String text, int width, int align, int height, Font f, Color fg, Color bg) {
+        JLabel l = new JLabel(text);
+        l.setFont(f);
+        l.setHorizontalAlignment(align);
+        Dimension d = new Dimension(width, height);
+        l.setPreferredSize(d);
+        l.setMaximumSize(d);
+        l.setMinimumSize(d);
+        l.setForeground(fg);
+        l.setBackground(bg);
+        l.setOpaque(true);
+        return l;
+    }
+
+    private JSeparator createVLine(int height) {
+        JSeparator vLine = new JSeparator(SwingConstants.VERTICAL);
+        vLine.setPreferredSize(new Dimension(1, height));
+        vLine.setForeground(new Color(60, 60, 60));
+        return vLine;
+    }
+}

--- a/src/colog/Main.java
+++ b/src/colog/Main.java
@@ -242,6 +242,7 @@ public class Main {
     private static void buildConversationList() {
         conversationListPanel.removeAll();
         conversationRows.clear();
+        conversationListPanel.add(new ConversationHeaderRowPanel());
         for (int i = 0; i < visibleConversations.size(); i++) {
             Conversation c = visibleConversations.get(i);
             ConversationRowPanel row = new ConversationRowPanel(i + 1, c);


### PR DESCRIPTION
## Summary
- add `ConversationHeaderRowPanel` to render column labels
- show header panel before list of conversations
- update log

## Testing
- `javac src/colog/*.java`
- `java -cp src colog.Main` *(fails: java.awt.HeadlessException)*

------
https://chatgpt.com/codex/tasks/task_b_687c3d8b5d54832190b8142dd6ae74d4