### PR TITLE
Fix conversation title styles

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -47,3 +47,5 @@ This file records all Codex-generated changes and implementations in this projec
 [2507200036][f910cb][FTR][REF] Set window to 800x600 and center on startup
 [2507200049][32d453][FTR][REF] Added separator lines in conversation rows
 [2507200053][55b60c][FTR] Added conversation list header panel
+
+[2507200104][bd134d4][BUG][REF] Styled conversation title panel

--- a/src/colog/ConversationPanel.java
+++ b/src/colog/ConversationPanel.java
@@ -3,6 +3,7 @@ package colog;
 import javax.swing.*;
 import java.awt.*;
 import static colog.UIStyle.*;
+import static colog.Theme.*;
 
 /**
  * Displays a conversation title followed by its exchange panels.
@@ -16,12 +17,22 @@ public class ConversationPanel extends JPanel {
 
     public ConversationPanel(String title, java.util.List<Exchange> visibleExchanges) {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        setBackground(DARK_BG);
+
+        JPanel titlePanel = new JPanel();
+        titlePanel.setLayout(new BoxLayout(titlePanel, BoxLayout.X_AXIS));
+        titlePanel.setBackground(new Color(32, 32, 32));
+        titlePanel.setBorder(BorderFactory.createEmptyBorder(8, 12, 4, 12));
 
         JLabel titleLabel = new JLabel(title);
-        titleLabel.setFont(BASE_FONT.deriveFont(Font.BOLD, 18f));
-        add(titleLabel);
+        titleLabel.setFont(new Font("SansSerif", Font.BOLD, 16));
+        titleLabel.setForeground(new Color(220, 220, 220));
+        titlePanel.add(titleLabel);
+        titlePanel.setAlignmentX(LEFT_ALIGNMENT);
+        add(titlePanel);
 
         JSeparator separator = new JSeparator(SwingConstants.HORIZONTAL);
+        separator.setForeground(new Color(80, 80, 80));
         add(separator);
 
         if (visibleExchanges.isEmpty()) {


### PR DESCRIPTION
## Summary
- style the conversation title panel to be visible on the dark background
- log the change

## Testing
- `javac -d out $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_b_687c402e20948321942dffb2696788e8