### PR TITLE
Fix exchange list vertical layout

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -49,3 +49,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507200053][55b60c][FTR] Added conversation list header panel
 
 [2507200104][bd134d4][BUG][REF] Styled conversation title panel
+[2507200120][8ad7d2][BUG][REF] Adjusted conversation title sizing and removed extra padding

--- a/src/colog/ConversationPanel.java
+++ b/src/colog/ConversationPanel.java
@@ -22,17 +22,24 @@ public class ConversationPanel extends JPanel {
         JPanel titlePanel = new JPanel();
         titlePanel.setLayout(new BoxLayout(titlePanel, BoxLayout.X_AXIS));
         titlePanel.setBackground(new Color(32, 32, 32));
-        titlePanel.setBorder(BorderFactory.createEmptyBorder(8, 12, 4, 12));
+        titlePanel.setBorder(BorderFactory.createEmptyBorder(4, 12, 4, 12));
 
         JLabel titleLabel = new JLabel(title);
         titleLabel.setFont(new Font("SansSerif", Font.BOLD, 16));
         titleLabel.setForeground(new Color(220, 220, 220));
         titlePanel.add(titleLabel);
+
+        FontMetrics fm = getFontMetrics(titleLabel.getFont());
+        int height = fm.getHeight() + 8; // 4px top/bottom padding
+        Dimension d = new Dimension(Short.MAX_VALUE, height);
+        titlePanel.setPreferredSize(d);
+        titlePanel.setMaximumSize(d);
         titlePanel.setAlignmentX(LEFT_ALIGNMENT);
         add(titlePanel);
 
         JSeparator separator = new JSeparator(SwingConstants.HORIZONTAL);
         separator.setForeground(new Color(80, 80, 80));
+        separator.setMaximumSize(new Dimension(Integer.MAX_VALUE, 1));
         add(separator);
 
         if (visibleExchanges.isEmpty()) {


### PR DESCRIPTION
## Summary
- tighten conversation title panel height
- add separator max size
- log adjustments

## Testing
- `javac` compilation

------
https://chatgpt.com/codex/tasks/task_b_687c43dc09548321a92dcd49176b7fa7