### PR TITLE
Fix ExchangePanel left alignment

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -50,3 +50,4 @@ This file records all Codex-generated changes and implementations in this projec
 
 [2507200104][bd134d4][BUG][REF] Styled conversation title panel
 [2507200120][8ad7d2][BUG][REF] Adjusted conversation title sizing and removed extra padding
+[2507200152][43fb49][BUG][REF] Fixed excessive indent in ExchangePanel layout

--- a/src/colog/ExchangePanel.java
+++ b/src/colog/ExchangePanel.java
@@ -149,6 +149,7 @@ public class ExchangePanel extends JPanel {
         area.setEditable(false);
         area.setFocusable(false);
         area.setBorder(null);
+        area.setMargin(new Insets(0, 0, 0, 0));
         area.setAlignmentX(LEFT_ALIGNMENT);
         return area;
     }
@@ -160,11 +161,11 @@ public class ExchangePanel extends JPanel {
         panel.setBackground(bg);
         panel.setOpaque(true);
         panel.setAlignmentX(LEFT_ALIGNMENT);
-        panel.setBorder(new EmptyBorder(4, 4, 4, 4));
+        panel.setBorder(new EmptyBorder(4, 0, 4, 0));
 
         JPanel wrapper = new JPanel();
         wrapper.setLayout(new BoxLayout(wrapper, BoxLayout.Y_AXIS));
-        wrapper.setBorder(BorderFactory.createEmptyBorder(0, indent ? 20 : 0, 0, 0));
+        wrapper.setBorder(BorderFactory.createEmptyBorder(0, indent ? 15 : 0, 0, 0));
         wrapper.setOpaque(false);
 
         JLabel label = new JLabel(labelText);


### PR DESCRIPTION
## Summary
- remove padding and margins on ExchangePanel sections
- reduce response indent to 15px
- log layout fix

## Testing
- `javac @sources.txt` *(compile check)*

------
https://chatgpt.com/codex/tasks/task_b_687c4b8626548321bcd4c727f87b29cb