### PR TITLE
Fix left panel row layout

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -51,3 +51,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507200104][bd134d4][BUG][REF] Styled conversation title panel
 [2507200120][8ad7d2][BUG][REF] Adjusted conversation title sizing and removed extra padding
 [2507200152][43fb49][BUG][REF] Fixed excessive indent in ExchangePanel layout
+[2507200212][4d5e55][BUG][REF] Adjusted conversation list layout and prompt count

--- a/src/colog/ConversationHeaderRowPanel.java
+++ b/src/colog/ConversationHeaderRowPanel.java
@@ -24,18 +24,20 @@ public class ConversationHeaderRowPanel extends JPanel {
         row.setLayout(new BoxLayout(row, BoxLayout.X_AXIS));
         row.setOpaque(true);
         row.setBackground(bg);
+        row.setAlignmentX(LEFT_ALIGNMENT);
 
-        row.add(createLabel("#", 30, SwingConstants.LEFT, fontHeight, font, fg, bg));
+        row.add(createLabel("#", 40, SwingConstants.LEFT, fontHeight, font, fg, bg));
         row.add(createVLine(fontHeight));
-        row.add(createLabel("Ex", 40, SwingConstants.RIGHT, fontHeight, font, fg, bg));
+        row.add(createLabel("Ex", 60, SwingConstants.LEFT, fontHeight, font, fg, bg));
         row.add(createVLine(fontHeight));
-        row.add(createLabel("Date/Time", 110, SwingConstants.LEFT, fontHeight, font, fg, bg));
+        row.add(createLabel("Date/Time", 140, SwingConstants.LEFT, fontHeight, font, fg, bg));
         row.add(createVLine(fontHeight));
-        row.add(createLabel("Title", 240, SwingConstants.LEFT, fontHeight, font, fg, bg));
+        row.add(createLabel("Title", 300, SwingConstants.LEFT, fontHeight, font, fg, bg));
         row.add(createVLine(fontHeight));
-        row.add(Box.createHorizontalGlue());
+        row.add(createLabel("Tags", 200, SwingConstants.RIGHT, fontHeight, font, fg, bg));
 
         row.setPreferredSize(new Dimension(Short.MAX_VALUE, fontHeight));
+        row.setMaximumSize(new Dimension(Short.MAX_VALUE, fontHeight));
         add(row);
         setPreferredSize(new Dimension(Short.MAX_VALUE, fontHeight + 1));
     }

--- a/src/colog/ConversationRowPanel.java
+++ b/src/colog/ConversationRowPanel.java
@@ -40,38 +40,39 @@ public class ConversationRowPanel extends JPanel {
         setBackground(DARK_BG);
 
         FontMetrics fm = getFontMetrics(BASE_FONT);
-        int fontHeight = fm.getHeight();
+        int rowHeight = fm.getHeight();
 
-        idLabel = createLabel("#" + index, 30, SwingConstants.LEFT, fontHeight);
-        countLabel = createLabel("\u00D7" + conversation.exchanges.size(), 40, SwingConstants.RIGHT, fontHeight);
-        timeLabel = createLabel(formatTimestamp(conversation), 110, SwingConstants.LEFT, fontHeight);
-        titleLabel = createLabel(conversation.title, 240, SwingConstants.LEFT, fontHeight);
-        tagLabel = createLabel(buildTagSummary(conversation), 100, SwingConstants.RIGHT, fontHeight);
+        idLabel = createLabel("#" + index, 40, SwingConstants.LEFT, rowHeight);
+        countLabel = createLabel(Integer.toString(conversation.exchanges.size()), 60, SwingConstants.LEFT, rowHeight);
+        timeLabel = createLabel(formatTimestamp(conversation), 140, SwingConstants.LEFT, rowHeight);
+        titleLabel = createLabel(conversation.title, 300, SwingConstants.LEFT, rowHeight);
+        tagLabel = createLabel(buildTagSummary(conversation), 200, SwingConstants.RIGHT, rowHeight);
 
         row = new JPanel();
         row.setLayout(new BoxLayout(row, BoxLayout.X_AXIS));
         row.setOpaque(true);
         row.setBackground(DARK_BG);
+        row.setAlignmentX(LEFT_ALIGNMENT);
 
         row.add(idLabel);
-        row.add(createVLine(fontHeight));
+        row.add(createVLine(rowHeight));
         row.add(countLabel);
-        row.add(createVLine(fontHeight));
+        row.add(createVLine(rowHeight));
         row.add(timeLabel);
-        row.add(createVLine(fontHeight));
+        row.add(createVLine(rowHeight));
         row.add(titleLabel);
-        row.add(createVLine(fontHeight));
-        row.add(Box.createHorizontalGlue());
+        row.add(createVLine(rowHeight));
         row.add(tagLabel);
 
-        row.setPreferredSize(new Dimension(Short.MAX_VALUE, fontHeight));
+        row.setPreferredSize(new Dimension(Short.MAX_VALUE, rowHeight));
+        row.setMaximumSize(new Dimension(Short.MAX_VALUE, rowHeight));
         add(row);
 
         JSeparator hLine = new JSeparator(SwingConstants.HORIZONTAL);
         hLine.setForeground(new Color(60, 60, 60));
         add(hLine);
 
-        setPreferredSize(new Dimension(Short.MAX_VALUE, fontHeight + 1));
+        setPreferredSize(new Dimension(Short.MAX_VALUE, rowHeight + 1));
 
         addMouseListener(new MouseAdapter() {
             @Override

--- a/src/colog/Main.java
+++ b/src/colog/Main.java
@@ -84,6 +84,7 @@ public class Main {
         conversationScrollPane = new JScrollPane(conversationListPanel);
         conversationScrollPane.getVerticalScrollBar().setUnitIncrement(24);
         conversationScrollPane.setBorder(BorderFactory.createEmptyBorder());
+        conversationScrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
         conversationScrollPane.getViewport().setBackground(DARK_BG);
 
         JPanel searchPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));


### PR DESCRIPTION
## Summary
- fix conversation list row column widths
- align header row
- remove complex prompt count format
- disable horizontal scrolling for conversation list
- log the change

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_b_687c502118c88321922ab61650f3c6b4