### PR TITLE
Update left panel header labels

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -52,3 +52,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507200120][8ad7d2][BUG][REF] Adjusted conversation title sizing and removed extra padding
 [2507200152][43fb49][BUG][REF] Fixed excessive indent in ExchangePanel layout
 [2507200212][4d5e55][BUG][REF] Adjusted conversation list layout and prompt count
+[2507200240][7b5401][FTR][REF] Updated conversation list header labels

--- a/src/colog/ConversationHeaderRowPanel.java
+++ b/src/colog/ConversationHeaderRowPanel.java
@@ -11,7 +11,7 @@ public class ConversationHeaderRowPanel extends JPanel {
     public ConversationHeaderRowPanel() {
         Color bg = new Color(40, 40, 40);
         Color fg = new Color(200, 200, 200);
-        Font font = BASE_FONT.deriveFont(Font.BOLD, BASE_FONT.getSize() - 1f);
+        Font font = BASE_FONT.deriveFont(Font.BOLD);
 
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         setOpaque(true);
@@ -26,13 +26,13 @@ public class ConversationHeaderRowPanel extends JPanel {
         row.setBackground(bg);
         row.setAlignmentX(LEFT_ALIGNMENT);
 
-        row.add(createLabel("#", 40, SwingConstants.LEFT, fontHeight, font, fg, bg));
+        row.add(createLabel("Index", 40, SwingConstants.LEFT, fontHeight, font, fg, bg));
         row.add(createVLine(fontHeight));
-        row.add(createLabel("Ex", 60, SwingConstants.LEFT, fontHeight, font, fg, bg));
+        row.add(createLabel("Prompt Count", 60, SwingConstants.LEFT, fontHeight, font, fg, bg));
         row.add(createVLine(fontHeight));
         row.add(createLabel("Date/Time", 140, SwingConstants.LEFT, fontHeight, font, fg, bg));
         row.add(createVLine(fontHeight));
-        row.add(createLabel("Title", 300, SwingConstants.LEFT, fontHeight, font, fg, bg));
+        row.add(createLabel("Conversation Title", 300, SwingConstants.LEFT, fontHeight, font, fg, bg));
         row.add(createVLine(fontHeight));
         row.add(createLabel("Tags", 200, SwingConstants.RIGHT, fontHeight, font, fg, bg));
 


### PR DESCRIPTION
## Summary
- rename column headers in `ConversationHeaderRowPanel`
- log the change in CODEX activity log

## Testing
- `javac @sources.txt` (all Java sources compiled)


------
https://chatgpt.com/codex/tasks/task_b_687c56cc256083218f2a33e531c06962