### PR TITLE
Increase global font size

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -54,3 +54,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507200212][4d5e55][BUG][REF] Adjusted conversation list layout and prompt count
 [2507200240][7b5401][FTR][REF] Updated conversation list header labels
 2507200259[7d0b28][BUG][REF] Fixed collapsed view rendering in ExchangePanel
+[2507200410][5b1094][FTR][REF] Increased base font size and updated layout metrics

--- a/src/colog/ConversationPanel.java
+++ b/src/colog/ConversationPanel.java
@@ -25,7 +25,7 @@ public class ConversationPanel extends JPanel {
         titlePanel.setBorder(BorderFactory.createEmptyBorder(4, 12, 4, 12));
 
         JLabel titleLabel = new JLabel(title);
-        titleLabel.setFont(new Font("SansSerif", Font.BOLD, 16));
+        titleLabel.setFont(BASE_FONT.deriveFont(Font.BOLD, BASE_FONT.getSize2D() + 2f));
         titleLabel.setForeground(new Color(220, 220, 220));
         titlePanel.add(titleLabel);
 

--- a/src/colog/ExchangePanel.java
+++ b/src/colog/ExchangePanel.java
@@ -102,7 +102,7 @@ public class ExchangePanel extends JPanel {
         wrapper.add(label);
 
         JLabel summaryLabel = new JLabel("Summary: " + summarize(text));
-        summaryLabel.setFont(BASE_FONT.deriveFont(Font.ITALIC, 11f));
+        summaryLabel.setFont(BASE_FONT.deriveFont(Font.ITALIC, BASE_FONT.getSize2D() - 1f));
         summaryLabel.setForeground(fg);
         summaryLabel.setBackground(bg);
         summaryLabel.setOpaque(true);

--- a/src/colog/UIStyle.java
+++ b/src/colog/UIStyle.java
@@ -7,5 +7,5 @@ import java.awt.Font;
  */
 public class UIStyle {
     /** Base font applied across the UI */
-    public static final Font BASE_FONT = new Font("SansSerif", Font.PLAIN, 12);
+    public static final Font BASE_FONT = new Font("SansSerif", Font.PLAIN, 14);
 }


### PR DESCRIPTION
## Summary
- bump `BASE_FONT` to 14pt
- base conversation titles on the global font
- size summary labels relative to the base font
- record activity in `CODEXLOG_CURRENT`

## Testing
- `javac -d /tmp/out src/colog/*.java`

------
https://chatgpt.com/codex/tasks/task_b_687c6bc952588321a7725cf41f190e3d