### PR TITLE
Improve conversation list layout

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -56,3 +56,4 @@ This file records all Codex-generated changes and implementations in this projec
 2507200259[7d0b28][BUG][REF] Fixed collapsed view rendering in ExchangePanel
 [2507200410][5b1094][FTR][REF] Increased base font size and updated layout metrics
 [2507200444][76fd64][DOC] Added CURRENT_CONTEXT.md context log
+[2507200507][aa00e8][BUG][REF] Fixed left panel column sizing and scrollbar

--- a/src/colog/ConversationHeaderRowPanel.java
+++ b/src/colog/ConversationHeaderRowPanel.java
@@ -26,15 +26,15 @@ public class ConversationHeaderRowPanel extends JPanel {
         row.setBackground(bg);
         row.setAlignmentX(LEFT_ALIGNMENT);
 
-        row.add(createLabel("Index", 40, SwingConstants.LEFT, fontHeight, font, fg, bg));
+        row.add(createCell("Index", 40, SwingConstants.LEFT, fontHeight, font, fg, bg));
         row.add(createVLine(fontHeight));
-        row.add(createLabel("Prompt Count", 60, SwingConstants.LEFT, fontHeight, font, fg, bg));
+        row.add(createCell("Prompt Count", 60, SwingConstants.LEFT, fontHeight, font, fg, bg));
         row.add(createVLine(fontHeight));
-        row.add(createLabel("Date/Time", 140, SwingConstants.LEFT, fontHeight, font, fg, bg));
+        row.add(createCell("Date/Time", 140, SwingConstants.LEFT, fontHeight, font, fg, bg));
         row.add(createVLine(fontHeight));
-        row.add(createLabel("Conversation Title", 300, SwingConstants.LEFT, fontHeight, font, fg, bg));
+        row.add(createCell("Conversation Title", 300, SwingConstants.LEFT, fontHeight, font, fg, bg));
         row.add(createVLine(fontHeight));
-        row.add(createLabel("Tags", 200, SwingConstants.RIGHT, fontHeight, font, fg, bg));
+        row.add(createCell("Tags", 200, SwingConstants.RIGHT, fontHeight, font, fg, bg));
 
         row.setPreferredSize(new Dimension(Short.MAX_VALUE, fontHeight));
         row.setMaximumSize(new Dimension(Short.MAX_VALUE, fontHeight));
@@ -50,10 +50,24 @@ public class ConversationHeaderRowPanel extends JPanel {
         l.setPreferredSize(d);
         l.setMaximumSize(d);
         l.setMinimumSize(d);
+        l.setBorder(BorderFactory.createLineBorder(Color.GRAY));
         l.setForeground(fg);
         l.setBackground(bg);
         l.setOpaque(true);
         return l;
+    }
+
+    private JPanel createCell(String text, int width, int align, int height, Font f, Color fg, Color bg) {
+        JLabel label = createLabel(text, width, align, height, f, fg, bg);
+        JPanel cell = new JPanel();
+        cell.setLayout(new BoxLayout(cell, BoxLayout.X_AXIS));
+        cell.setOpaque(false);
+        Dimension d = new Dimension(width, height);
+        cell.setPreferredSize(d);
+        cell.setMaximumSize(d);
+        cell.setMinimumSize(d);
+        cell.add(label);
+        return cell;
     }
 
     private JSeparator createVLine(int height) {

--- a/src/colog/ConversationRowPanel.java
+++ b/src/colog/ConversationRowPanel.java
@@ -54,15 +54,15 @@ public class ConversationRowPanel extends JPanel {
         row.setBackground(DARK_BG);
         row.setAlignmentX(LEFT_ALIGNMENT);
 
-        row.add(idLabel);
+        row.add(createCell(idLabel, 40, rowHeight));
         row.add(createVLine(rowHeight));
-        row.add(countLabel);
+        row.add(createCell(countLabel, 60, rowHeight));
         row.add(createVLine(rowHeight));
-        row.add(timeLabel);
+        row.add(createCell(timeLabel, 140, rowHeight));
         row.add(createVLine(rowHeight));
-        row.add(titleLabel);
+        row.add(createCell(titleLabel, 300, rowHeight));
         row.add(createVLine(rowHeight));
-        row.add(tagLabel);
+        row.add(createCell(tagLabel, 200, rowHeight));
 
         row.setPreferredSize(new Dimension(Short.MAX_VALUE, rowHeight));
         row.setMaximumSize(new Dimension(Short.MAX_VALUE, rowHeight));
@@ -90,10 +90,23 @@ public class ConversationRowPanel extends JPanel {
         l.setPreferredSize(d);
         l.setMaximumSize(d);
         l.setMinimumSize(d);
+        l.setBorder(BorderFactory.createLineBorder(Color.GRAY));
         l.setForeground(LIGHT_TEXT);
         l.setBackground(DARK_BG);
         l.setOpaque(true);
         return l;
+    }
+
+    private JPanel createCell(JLabel label, int width, int height) {
+        JPanel cell = new JPanel();
+        cell.setLayout(new BoxLayout(cell, BoxLayout.X_AXIS));
+        cell.setOpaque(false);
+        Dimension d = new Dimension(width, height);
+        cell.setPreferredSize(d);
+        cell.setMaximumSize(d);
+        cell.setMinimumSize(d);
+        cell.add(label);
+        return cell;
     }
 
     private JSeparator createVLine(int height) {

--- a/src/colog/Main.java
+++ b/src/colog/Main.java
@@ -84,7 +84,7 @@ public class Main {
         conversationScrollPane = new JScrollPane(conversationListPanel);
         conversationScrollPane.getVerticalScrollBar().setUnitIncrement(24);
         conversationScrollPane.setBorder(BorderFactory.createEmptyBorder());
-        conversationScrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        conversationScrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
         conversationScrollPane.getViewport().setBackground(DARK_BG);
 
         JPanel searchPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
@@ -251,6 +251,9 @@ public class Main {
             conversationRows.add(row);
             conversationListPanel.add(row);
         }
+        Dimension listSize = new Dimension(744, 0);
+        conversationListPanel.setPreferredSize(listSize);
+        conversationListPanel.setMinimumSize(listSize);
     }
 
     private static void selectConversation(int index) {


### PR DESCRIPTION
## Summary
- fix column alignment by wrapping labels in fixed-size cells
- add temporary debug borders around column labels
- allow horizontal scrolling for conversation list
- set fixed width for conversation list panel
- update activity log

## Testing
- `javac src/colog/*.java`

------
https://chatgpt.com/codex/tasks/task_b_687c78d288d083218d7cc045a74f6abd