### PR TITLE
Adjust conversation list column layout

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -57,3 +57,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507200410][5b1094][FTR][REF] Increased base font size and updated layout metrics
 [2507200444][76fd64][DOC] Added CURRENT_CONTEXT.md context log
 [2507200507][aa00e8][BUG][REF] Fixed left panel column sizing and scrollbar
+[2507200520][057a15][REF] Updated conversation panel column widths and removed tags column

--- a/src/colog/ConversationHeaderRowPanel.java
+++ b/src/colog/ConversationHeaderRowPanel.java
@@ -26,15 +26,13 @@ public class ConversationHeaderRowPanel extends JPanel {
         row.setBackground(bg);
         row.setAlignmentX(LEFT_ALIGNMENT);
 
-        row.add(createCell("Index", 40, SwingConstants.LEFT, fontHeight, font, fg, bg));
+        row.add(createCell("Index", 80, SwingConstants.LEFT, fontHeight, font, fg, bg));
         row.add(createVLine(fontHeight));
-        row.add(createCell("Prompt Count", 60, SwingConstants.LEFT, fontHeight, font, fg, bg));
+        row.add(createCell("Prompt Count", 120, SwingConstants.LEFT, fontHeight, font, fg, bg));
         row.add(createVLine(fontHeight));
         row.add(createCell("Date/Time", 140, SwingConstants.LEFT, fontHeight, font, fg, bg));
         row.add(createVLine(fontHeight));
         row.add(createCell("Conversation Title", 300, SwingConstants.LEFT, fontHeight, font, fg, bg));
-        row.add(createVLine(fontHeight));
-        row.add(createCell("Tags", 200, SwingConstants.RIGHT, fontHeight, font, fg, bg));
 
         row.setPreferredSize(new Dimension(Short.MAX_VALUE, fontHeight));
         row.setMaximumSize(new Dimension(Short.MAX_VALUE, fontHeight));

--- a/src/colog/ConversationRowPanel.java
+++ b/src/colog/ConversationRowPanel.java
@@ -28,7 +28,6 @@ public class ConversationRowPanel extends JPanel {
     private final JLabel timeLabel;
     private final JLabel countLabel;
     private final JLabel titleLabel;
-    private final JLabel tagLabel;
     private final JPanel row;
 
     public ConversationRowPanel(int index, Conversation conversation) {
@@ -42,11 +41,10 @@ public class ConversationRowPanel extends JPanel {
         FontMetrics fm = getFontMetrics(BASE_FONT);
         int rowHeight = fm.getHeight();
 
-        idLabel = createLabel("#" + index, 40, SwingConstants.LEFT, rowHeight);
-        countLabel = createLabel(Integer.toString(conversation.exchanges.size()), 60, SwingConstants.LEFT, rowHeight);
+        idLabel = createLabel("#" + index, 80, SwingConstants.LEFT, rowHeight);
+        countLabel = createLabel(Integer.toString(conversation.exchanges.size()), 120, SwingConstants.LEFT, rowHeight);
         timeLabel = createLabel(formatTimestamp(conversation), 140, SwingConstants.LEFT, rowHeight);
         titleLabel = createLabel(conversation.title, 300, SwingConstants.LEFT, rowHeight);
-        tagLabel = createLabel(buildTagSummary(conversation), 200, SwingConstants.RIGHT, rowHeight);
 
         row = new JPanel();
         row.setLayout(new BoxLayout(row, BoxLayout.X_AXIS));
@@ -54,15 +52,13 @@ public class ConversationRowPanel extends JPanel {
         row.setBackground(DARK_BG);
         row.setAlignmentX(LEFT_ALIGNMENT);
 
-        row.add(createCell(idLabel, 40, rowHeight));
+        row.add(createCell(idLabel, 80, rowHeight));
         row.add(createVLine(rowHeight));
-        row.add(createCell(countLabel, 60, rowHeight));
+        row.add(createCell(countLabel, 120, rowHeight));
         row.add(createVLine(rowHeight));
         row.add(createCell(timeLabel, 140, rowHeight));
         row.add(createVLine(rowHeight));
         row.add(createCell(titleLabel, 300, rowHeight));
-        row.add(createVLine(rowHeight));
-        row.add(createCell(tagLabel, 200, rowHeight));
 
         row.setPreferredSize(new Dimension(Short.MAX_VALUE, rowHeight));
         row.setMaximumSize(new Dimension(Short.MAX_VALUE, rowHeight));


### PR DESCRIPTION
## Summary
- widen index and prompt count columns in conversation header panel
- remove tags column from conversation header
- match widths in conversation row panel and drop tag label
- log column layout update

## Testing
- `javac @sources.txt -d out`

------
https://chatgpt.com/codex/tasks/task_b_687c7c3ed9848321888139d28f809119