### PR TITLE
Fix dark theme rendering on initial load

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -58,3 +58,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507200444][76fd64][DOC] Added CURRENT_CONTEXT.md context log
 [2507200507][aa00e8][BUG][REF] Fixed left panel column sizing and scrollbar
 [2507200520][057a15][REF] Updated conversation panel column widths and removed tags column
+[2507200546][3a55d0b][BUG][REF] Ensured dark theme background on initial conversation load

--- a/TASKS.md
+++ b/TASKS.md
@@ -8,6 +8,7 @@
 - Fix text clipping and ensure correct heights for collapsed and expanded ExchangePanel states
 - Improve ExchangePanel tag labels with clickable styling and hover feedback
 - Increase global font size to improve readability
+- Fix right panel background not applying dark theme on initial file load
 
 ## 🔜 Upcoming
 - Set up initial project structure and documentation

--- a/src/colog/ConversationPanel.java
+++ b/src/colog/ConversationPanel.java
@@ -18,10 +18,12 @@ public class ConversationPanel extends JPanel {
     public ConversationPanel(String title, java.util.List<Exchange> visibleExchanges) {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         setBackground(DARK_BG);
+        setOpaque(true);
 
         JPanel titlePanel = new JPanel();
         titlePanel.setLayout(new BoxLayout(titlePanel, BoxLayout.X_AXIS));
         titlePanel.setBackground(new Color(32, 32, 32));
+        titlePanel.setOpaque(true);
         titlePanel.setBorder(BorderFactory.createEmptyBorder(4, 12, 4, 12));
 
         JLabel titleLabel = new JLabel(title);

--- a/src/colog/ExchangePanel.java
+++ b/src/colog/ExchangePanel.java
@@ -40,6 +40,7 @@ public class ExchangePanel extends JPanel {
 
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         setBackground(DARK_BG);
+        setOpaque(true);
         setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
 
         expandLabel = new JLabel("\u2BC8");

--- a/src/colog/Main.java
+++ b/src/colog/Main.java
@@ -72,20 +72,28 @@ public class Main {
         container = new JPanel();
         container.setLayout(new BoxLayout(container, BoxLayout.Y_AXIS));
         container.setBackground(DARK_BG);
+        container.setOpaque(true);
 
         scrollPane = new JScrollPane(container);
         scrollPane.getVerticalScrollBar().setUnitIncrement(24);
         scrollPane.setBorder(BorderFactory.createEmptyBorder());
+        scrollPane.setBackground(DARK_BG);
+        scrollPane.setOpaque(true);
         scrollPane.getViewport().setBackground(DARK_BG);
+        scrollPane.getViewport().setOpaque(true);
 
         conversationListPanel = new JPanel();
         conversationListPanel.setLayout(new BoxLayout(conversationListPanel, BoxLayout.Y_AXIS));
         conversationListPanel.setBackground(DARK_BG);
+        conversationListPanel.setOpaque(true);
         conversationScrollPane = new JScrollPane(conversationListPanel);
         conversationScrollPane.getVerticalScrollBar().setUnitIncrement(24);
         conversationScrollPane.setBorder(BorderFactory.createEmptyBorder());
         conversationScrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+        conversationScrollPane.setBackground(DARK_BG);
+        conversationScrollPane.setOpaque(true);
         conversationScrollPane.getViewport().setBackground(DARK_BG);
+        conversationScrollPane.getViewport().setOpaque(true);
 
         JPanel searchPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
         searchPanel.setBackground(DARK_BG);


### PR DESCRIPTION
## Summary
- ensure right panel uses dark theme on first view
- mark conversation panel, exchange panel, and scroll panes as opaque
- update tasks
- log update

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_b_687c81f5bba48321b3bd47b56d207b6f