### PR TITLE
Fix conversation list column spacing

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -59,3 +59,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507200507][aa00e8][BUG][REF] Fixed left panel column sizing and scrollbar
 [2507200520][057a15][REF] Updated conversation panel column widths and removed tags column
 [2507200546][3a55d0b][BUG][REF] Ensured dark theme background on initial conversation load
+[2507200843][e0abd9e][BUG][REF] Removed separator artifacts in conversation list

--- a/src/colog/ConversationHeaderRowPanel.java
+++ b/src/colog/ConversationHeaderRowPanel.java
@@ -25,14 +25,12 @@ public class ConversationHeaderRowPanel extends JPanel {
         row.setOpaque(true);
         row.setBackground(bg);
         row.setAlignmentX(LEFT_ALIGNMENT);
+        row.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, new Color(60, 60, 60)));
 
-        row.add(createCell("Index", 80, SwingConstants.LEFT, fontHeight, font, fg, bg));
-        row.add(createVLine(fontHeight));
-        row.add(createCell("Prompt Count", 120, SwingConstants.LEFT, fontHeight, font, fg, bg));
-        row.add(createVLine(fontHeight));
-        row.add(createCell("Date/Time", 140, SwingConstants.LEFT, fontHeight, font, fg, bg));
-        row.add(createVLine(fontHeight));
-        row.add(createCell("Conversation Title", 300, SwingConstants.LEFT, fontHeight, font, fg, bg));
+        row.add(createCell("Index", 80, SwingConstants.LEFT, fontHeight, font, fg, bg, true));
+        row.add(createCell("Prompt Count", 120, SwingConstants.LEFT, fontHeight, font, fg, bg, true));
+        row.add(createCell("Date/Time", 140, SwingConstants.LEFT, fontHeight, font, fg, bg, true));
+        row.add(createCell("Conversation Title", 300, SwingConstants.LEFT, fontHeight, font, fg, bg, false));
 
         row.setPreferredSize(new Dimension(Short.MAX_VALUE, fontHeight));
         row.setMaximumSize(new Dimension(Short.MAX_VALUE, fontHeight));
@@ -48,15 +46,18 @@ public class ConversationHeaderRowPanel extends JPanel {
         l.setPreferredSize(d);
         l.setMaximumSize(d);
         l.setMinimumSize(d);
-        l.setBorder(BorderFactory.createLineBorder(Color.GRAY));
+        l.setBorder(BorderFactory.createEmptyBorder());
         l.setForeground(fg);
         l.setBackground(bg);
         l.setOpaque(true);
         return l;
     }
 
-    private JPanel createCell(String text, int width, int align, int height, Font f, Color fg, Color bg) {
+    private JPanel createCell(String text, int width, int align, int height, Font f, Color fg, Color bg, boolean addRightBorder) {
         JLabel label = createLabel(text, width, align, height, f, fg, bg);
+        if (addRightBorder) {
+            label.setBorder(BorderFactory.createMatteBorder(0, 0, 0, 1, new Color(60, 60, 60)));
+        }
         JPanel cell = new JPanel();
         cell.setLayout(new BoxLayout(cell, BoxLayout.X_AXIS));
         cell.setOpaque(false);
@@ -68,10 +69,4 @@ public class ConversationHeaderRowPanel extends JPanel {
         return cell;
     }
 
-    private JSeparator createVLine(int height) {
-        JSeparator vLine = new JSeparator(SwingConstants.VERTICAL);
-        vLine.setPreferredSize(new Dimension(1, height));
-        vLine.setForeground(new Color(60, 60, 60));
-        return vLine;
-    }
 }

--- a/src/colog/ConversationRowPanel.java
+++ b/src/colog/ConversationRowPanel.java
@@ -52,13 +52,10 @@ public class ConversationRowPanel extends JPanel {
         row.setBackground(DARK_BG);
         row.setAlignmentX(LEFT_ALIGNMENT);
 
-        row.add(createCell(idLabel, 80, rowHeight));
-        row.add(createVLine(rowHeight));
-        row.add(createCell(countLabel, 120, rowHeight));
-        row.add(createVLine(rowHeight));
-        row.add(createCell(timeLabel, 140, rowHeight));
-        row.add(createVLine(rowHeight));
-        row.add(createCell(titleLabel, 300, rowHeight));
+        row.add(createCell(idLabel, 80, rowHeight, true));
+        row.add(createCell(countLabel, 120, rowHeight, true));
+        row.add(createCell(timeLabel, 140, rowHeight, true));
+        row.add(createCell(titleLabel, 300, rowHeight, false));
 
         row.setPreferredSize(new Dimension(Short.MAX_VALUE, rowHeight));
         row.setMaximumSize(new Dimension(Short.MAX_VALUE, rowHeight));
@@ -86,14 +83,14 @@ public class ConversationRowPanel extends JPanel {
         l.setPreferredSize(d);
         l.setMaximumSize(d);
         l.setMinimumSize(d);
-        l.setBorder(BorderFactory.createLineBorder(Color.GRAY));
+        l.setBorder(BorderFactory.createEmptyBorder());
         l.setForeground(LIGHT_TEXT);
         l.setBackground(DARK_BG);
         l.setOpaque(true);
         return l;
     }
 
-    private JPanel createCell(JLabel label, int width, int height) {
+    private JPanel createCell(JLabel label, int width, int height, boolean addRightBorder) {
         JPanel cell = new JPanel();
         cell.setLayout(new BoxLayout(cell, BoxLayout.X_AXIS));
         cell.setOpaque(false);
@@ -101,16 +98,13 @@ public class ConversationRowPanel extends JPanel {
         cell.setPreferredSize(d);
         cell.setMaximumSize(d);
         cell.setMinimumSize(d);
+        if (addRightBorder) {
+            label.setBorder(BorderFactory.createMatteBorder(0, 0, 0, 1, new Color(60, 60, 60)));
+        }
         cell.add(label);
         return cell;
     }
 
-    private JSeparator createVLine(int height) {
-        JSeparator vLine = new JSeparator(SwingConstants.VERTICAL);
-        vLine.setPreferredSize(new Dimension(1, height));
-        vLine.setForeground(new Color(60, 60, 60));
-        return vLine;
-    }
 
     private static String formatTimestamp(Conversation conversation) {
         if (conversation.exchanges.isEmpty()) return "";


### PR DESCRIPTION
## Summary
- remove extra vertical separators from conversation list header and rows
- clean up label borders and add matte borders instead
- log fix

## Testing
- `javac -classpath . $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_b_687cab8432c08321a24eced5d3807586