### PR TITLE
docs: migrate to flutter stack

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -60,3 +60,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507200520][057a15][REF] Updated conversation panel column widths and removed tags column
 [2507200546][3a55d0b][BUG][REF] Ensured dark theme background on initial conversation load
 [2507200843][e0abd9e][BUG][REF] Removed separator artifacts in conversation list
+[2507201927][efac7c][DOC] Updated tech stack and tasks for Flutter transition

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -99,21 +99,21 @@ Colog V3 helps you *capture, structure, and reuse* your development conversation
 
 ### 🎯 Goals
 
-- **Simplicity**
-- **Minimal tooling**
-- **Total control over source code**
-- **Codex-friendly, low-friction architecture**
+- **Cross-platform UI flexibility**
+- **Maintainable modern codebase**
+- **Codex-friendly, declarative structure**
+- **Future compatibility with minimal maintenance overhead**
 
 ### ⚙️ Platform & Tools
 
-| Component           | Choice                   | Notes |
-|---------------------|---------------------------|-------|
-| Language            | Java 21+                  | Modern features but stable and predictable |
-| UI Toolkit          | Swing                     | Lightweight, portable, no heavy UI dependencies |
-| Build System        | None                      | No Gradle, no Maven — compilation via simple scripts or IDE |
-| LLM Integration     | Optional API (e.g. OpenAI)| Local inference optional in future |
-| Version Control     | Git                       | Local + GitHub remote |
-| Coding Model        | Codex-led implementation  | ChatGPT manages design, Codex writes code, user reviews/fixes |
+| Component           | Choice                      | Notes |
+|---------------------|------------------------------|-------|
+| Language            | Dart                         | Primary language for Flutter |
+| Framework           | Flutter (latest stable)      | For building desktop/mobile/web app |
+| Editor              | VS Code                      | Codex-friendly and extensible |
+| Coding Model        | Codex-led implementation     | ChatGPT handles design and coordination, Codex implements |
+| Versioning          | Git + GitHub                 | Used for all source control |
+| Dependency Policy   | Use latest stable packages   | Avoid future compatibility cascades |
 
 ---
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -5,12 +5,31 @@
 
 ## 🚧 In Progress
 - None
-- Fix text clipping and ensure correct heights for collapsed and expanded ExchangePanel states
-- Improve ExchangePanel tag labels with clickable styling and hover feedback
+- Improve tag labels with clickable styling and hover feedback
 - Increase global font size to improve readability
 - Fix right panel background not applying dark theme on initial file load
 
 ## 🔜 Upcoming
 - Set up initial project structure and documentation
 - Define build and run scripts
+
+- Add initial Flutter app skeleton
+- Implement file selection and JSON preview
+- Display scrollable conversation and exchange views
+- Integrate custom JSON parser for ChatGPT export format
+- Build dynamic mapping of JSON into Exchanges grouped by Conversation
+- Support toggleable expand/collapse per Exchange
+- Preserve expand state and scroll position
+- Automatically summarize exchanges and infer tags
+- Support multi-conversation JSON files
+- Implement full-text search and filter UI
+- Add summary sidebar with clickable exchange navigation
+- Add tag-based filtering with interactive labels
+- Implement tag label interactivity
+- Format Exchange prompt and response sections
+- Display preview summary lines per exchange
+- Indent responses in a wrapper panel
+- Show exchange counts in conversation rows
+- Apply dark theme styling throughout
+- Add conversation list header panel with labels
 


### PR DESCRIPTION
## Summary
- update tech stack and development model for Flutter
- add high-level Flutter tasks
- log Flutter transition updates

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_687d42c76b008321b55ae0f5609ec962