### PR TITLE
Implement Flutter skeleton with menu and dark theme

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -62,3 +62,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507200843][e0abd9e][BUG][REF] Removed separator artifacts in conversation list
 [2507201927][efac7c][DOC] Updated tech stack and tasks for Flutter transition
 [2507202002][0757fe][SNC] Added Flutter .gitignore
+[2507212025][1f76c02][FTR][REF] Added maximized window, dark blue theme, and File menu with Open/Exit options and persistent file picker

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,102 @@
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  if (Platform.isWindows) {
+    _maximizeWindow();
+  }
+  runApp(const CologApp());
+}
+
+void _maximizeWindow() {
+  final user32 = DynamicLibrary.open('user32.dll');
+  final getForegroundWindow = user32.lookupFunction<IntPtr Function(), int Function()>('GetForegroundWindow');
+  final showWindow = user32.lookupFunction<Int32 Function(IntPtr, Int32), int Function(int, int)>('ShowWindow');
+  const swMaximize = 3;
+  final hwnd = getForegroundWindow();
+  showWindow(hwnd, swMaximize);
+}
+
+class CologApp extends StatelessWidget {
+  const CologApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    const darkBlue = Color(0xFF0B1E2D);
+    return MaterialApp(
+      title: 'Colog V3',
+      theme: ThemeData(
+        brightness: Brightness.dark,
+        colorScheme: const ColorScheme.dark(
+          primary: Color(0xFF1E88E5),
+          background: darkBlue,
+        ),
+        scaffoldBackgroundColor: darkBlue,
+        useMaterial3: true,
+      ),
+      home: const HomePage(),
+    );
+  }
+}
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  Future<void> _openJsonFile() async {
+    final prefs = await SharedPreferences.getInstance();
+    final initialDir = prefs.getString('last_dir');
+    const typeGroup = XTypeGroup(label: 'json', extensions: ['json']);
+    final file = await openFile(
+      initialDirectory: initialDir,
+      acceptedTypeGroups: [typeGroup],
+    );
+    if (file != null) {
+      prefs.setString('last_dir', File(file.path).parent.path);
+      // TODO: handle loaded JSON file
+    }
+  }
+
+  void _exitApp() {
+    exit(0);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Colog V3'),
+        actions: [
+          MenuBar(children: [
+            SubmenuButton(
+              menuChildren: [
+                MenuItemButton(
+                  onPressed: _openJsonFile,
+                  child: const Text('Open'),
+                ),
+                const MenuDivider(),
+                MenuItemButton(
+                  onPressed: _exitApp,
+                  child: const Text('Exit'),
+                ),
+              ],
+              child: const Text('File'),
+            ),
+          ])
+        ],
+      ),
+      body: const Center(
+        child: Text('Welcome to Colog V3'),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,20 @@
+name: colog_v3
+description: Colog V3 Flutter application
+publish_to: 'none'
+
+environment:
+  sdk: '>=3.4.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  file_selector: ^1.0.3
+  shared_preferences: ^2.2.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- create `lib/main.dart` with a maximized window on Windows
- add dark blue theme and File menu with Open/Exit
- persist last directory using `shared_preferences`
- update `pubspec.yaml` with Flutter dependencies
- record implementation in CODEX log

## Testing
- `flutter --version` *(fails: command not found)*
- `dart format --output none lib/main.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687d5031d4f88321b1297cf387e40cf3