### PR TITLE
Fix MenuDivider error for stable Flutter

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -63,3 +63,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507201927][efac7c][DOC] Updated tech stack and tasks for Flutter transition
 [2507202002][0757fe][SNC] Added Flutter .gitignore
 [2507212025][1f76c02][FTR][REF] Added maximized window, dark blue theme, and File menu with Open/Exit options and persistent file picker
+[2507212046][1310fb][ERR][REF] Replaced unsupported MenuDivider with SizedBox

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -83,7 +83,7 @@ class _HomePageState extends State<HomePage> {
                   onPressed: _openJsonFile,
                   child: const Text('Open'),
                 ),
-                const MenuDivider(),
+                const SizedBox(height: 8),
                 MenuItemButton(
                   onPressed: _exitApp,
                   child: const Text('Exit'),


### PR DESCRIPTION
## Summary
- replace `MenuDivider` with `SizedBox(height: 8)`
- update CODEX log

## Testing
- `flutter/bin/dart --version` *(fails: command not found)*
- `flutter/bin/flutter doctor` *(fails to resolve Flutter version)*
- `flutter/bin/dart analyze` *(hangs and fails)*

------
https://chatgpt.com/codex/tasks/task_b_687d53e3c28483218e9a2bd34d14c1ce