### PR TITLE
Implement ChatGPT JSON loader and display

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -64,3 +64,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507202002][0757fe][SNC] Added Flutter .gitignore
 [2507212025][1f76c02][FTR][REF] Added maximized window, dark blue theme, and File menu with Open/Exit options and persistent file picker
 [2507212046][1310fb][ERR][REF] Replaced unsupported MenuDivider with SizedBox
+[2507212106][c4d10d][FTR][REF] Replaced app title, repositioned File menu, added full ChatGPT JSON loader with structured display and escaped character rendering

--- a/lib/models/conversation.dart
+++ b/lib/models/conversation.dart
@@ -1,0 +1,13 @@
+import 'exchange.dart';
+
+class Conversation {
+  final String title;
+  final DateTime timestamp;
+  final List<Exchange> exchanges;
+
+  Conversation({
+    required this.title,
+    required this.timestamp,
+    required this.exchanges,
+  });
+}

--- a/lib/models/exchange.dart
+++ b/lib/models/exchange.dart
@@ -1,0 +1,13 @@
+class Exchange {
+  final String user;
+  final String agent;
+  final DateTime userTime;
+  final DateTime agentTime;
+
+  Exchange({
+    required this.user,
+    required this.agent,
+    required this.userTime,
+    required this.agentTime,
+  });
+}

--- a/lib/services/json_loader.dart
+++ b/lib/services/json_loader.dart
@@ -1,0 +1,100 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+import '../models/conversation.dart';
+import '../models/exchange.dart';
+
+class JsonLoader {
+  static Future<List<Conversation>> loadConversations(String path) {
+    return compute(_parseFile, path);
+  }
+}
+
+Future<List<Conversation>> _parseFile(String path) async {
+  final raw = await File(path).readAsString();
+  final data = jsonDecode(raw);
+  return _parseData(data);
+}
+
+List<Conversation> _parseData(dynamic data) {
+  if (data is Map && data.containsKey('conversations')) {
+    final list = data['conversations'];
+    if (list is List) {
+      return list.map((c) => _parseConversation(c)).toList();
+    }
+  }
+  if (data is List) {
+    return data.map((c) => _parseConversation(c)).toList();
+  }
+  if (data is Map) {
+    return [_parseConversation(data)];
+  }
+  return [];
+}
+
+Conversation _parseConversation(Map raw) {
+  final title = raw['title'] as String? ?? 'Untitled';
+  final tsSeconds = raw['create_time'];
+  final ts = tsSeconds is num
+      ? DateTime.fromMillisecondsSinceEpoch((tsSeconds * 1000).toInt())
+      : DateTime.now();
+  final mapping = raw['mapping'] as Map? ?? {};
+  final exchanges = <Exchange>[];
+
+  for (final node in mapping.values) {
+    if (node is Map) {
+      final message = node['message'];
+      if (message is Map) {
+        final author = message['author'];
+        if (author is Map && author['role'] == 'user') {
+          final children = node['children'];
+          if (children is List && children.isNotEmpty) {
+            final child = mapping[children.first];
+            if (child is Map) {
+              final childMsg = child['message'];
+              if (childMsg is Map) {
+                final childAuthor = childMsg['author'];
+                if (childAuthor is Map && childAuthor['role'] == 'assistant') {
+                  final userText = _extractText(message);
+                  final agentText = _extractText(childMsg);
+                  final userTimeSeconds = message['create_time'];
+                  final agentTimeSeconds = childMsg['create_time'];
+                  final userTime = userTimeSeconds is num
+                      ? DateTime.fromMillisecondsSinceEpoch(
+                          (userTimeSeconds * 1000).toInt())
+                      : ts;
+                  final agentTime = agentTimeSeconds is num
+                      ? DateTime.fromMillisecondsSinceEpoch(
+                          (agentTimeSeconds * 1000).toInt())
+                      : userTime;
+                  exchanges.add(Exchange(
+                    user: userText,
+                    agent: agentText,
+                    userTime: userTime,
+                    agentTime: agentTime,
+                  ));
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return Conversation(title: title, timestamp: ts, exchanges: exchanges);
+}
+
+String _extractText(Map msg) {
+  final content = msg['content'];
+  if (content is Map) {
+    final parts = content['parts'];
+    if (parts is List && parts.isNotEmpty) {
+      final text = parts.first;
+      if (text is String) return text;
+    }
+  }
+  return '';
+}

--- a/lib/widgets/conversation_view.dart
+++ b/lib/widgets/conversation_view.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/conversation.dart';
+import '../models/exchange.dart';
+
+class ConversationView extends StatelessWidget {
+  final List<Conversation> conversations;
+  const ConversationView({super.key, required this.conversations});
+
+  @override
+  Widget build(BuildContext context) {
+    final items = <_ListItem>[];
+    for (final c in conversations) {
+      items.add(_ListItem.conversation(c));
+      for (final ex in c.exchanges) {
+        items.add(_ListItem.exchange(ex));
+      }
+    }
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: items.length,
+      itemBuilder: (context, index) {
+        final item = items[index];
+        return item.when(
+          conversation: (c) => _buildConversationHeader(context, c),
+          exchange: (e) => _buildExchange(context, e),
+        );
+      },
+    );
+  }
+
+  Widget _buildConversationHeader(BuildContext context, Conversation conv) {
+    final ts = DateFormat('yy/MM/dd HH:mm:ss').format(conv.timestamp);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Text(
+        '${conv.title} ($ts)',
+        style: Theme.of(context)
+            .textTheme
+            .titleLarge
+            ?.copyWith(fontWeight: FontWeight.bold),
+      ),
+    );
+  }
+
+  Widget _buildExchange(BuildContext context, Exchange ex) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(left: 8.0, bottom: 4.0),
+          child: Text('User : ${ex.user.replaceAll("\r", "")}') ,
+        ),
+        Padding(
+          padding: const EdgeInsets.only(left: 24.0, bottom: 4.0),
+          child: Text('Agent : ${ex.agent.replaceAll("\r", "")}'),
+        ),
+        const Divider(height: 16),
+      ],
+    );
+  }
+}
+
+class _ListItem {
+  final Conversation? conversation;
+  final Exchange? exchange;
+
+  _ListItem.conversation(this.conversation) : exchange = null;
+  _ListItem.exchange(this.exchange) : conversation = null;
+
+  T when<T>({
+    required T Function(Conversation) conversation,
+    required T Function(Exchange) exchange,
+  }) {
+    if (this.conversation != null) return conversation(this.conversation!);
+    return exchange(this.exchange!);
+  }
+}

--- a/lib/widgets/menu_bar.dart
+++ b/lib/widgets/menu_bar.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class AppMenuBar extends StatelessWidget {
+  final VoidCallback onOpen;
+  final VoidCallback onExit;
+
+  const AppMenuBar({super.key, required this.onOpen, required this.onExit});
+
+  @override
+  Widget build(BuildContext context) {
+    return MenuBar(children: [
+      SubmenuButton(
+        menuChildren: [
+          MenuItemButton(
+            onPressed: onOpen,
+            child: const Text('Open'),
+          ),
+          const SizedBox(height: 8),
+          MenuItemButton(
+            onPressed: onExit,
+            child: const Text('Exit'),
+          ),
+        ],
+        child: const Text('File'),
+      ),
+    ]);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
     sdk: flutter
   file_selector: ^1.0.3
   shared_preferences: ^2.2.2
+  intl: ^0.18.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add models for `Conversation` and `Exchange`
- build JSON loader service using isolates for large files
- show parsed conversations in a scrollable view
- create a reusable file menu widget
- reposition menu into the app bar and remove window title
- declare `intl` dependency for date formatting

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687d59b5c71c8321b6deaa03bb5e9f63