### PR TITLE
Implement Exchange object and refactor JSON loader

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -66,3 +66,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507212046][1310fb][ERR][REF] Replaced unsupported MenuDivider with SizedBox
 [2507212106][c4d10d][FTR][REF] Replaced app title, repositioned File menu, added full ChatGPT JSON loader with structured display and escaped character rendering
 [2507202119][e05fac][FTR][ERR] Added non-blocking JSON load error panel
+[250721hhmm][f37ba41][FTR][REF] Added Exchange object to encapsulate prompt-response pairs, updated JSON parsing and view logic

--- a/lib/models/exchange.dart
+++ b/lib/models/exchange.dart
@@ -1,13 +1,13 @@
 class Exchange {
-  final String user;
-  final String agent;
-  final DateTime userTime;
-  final DateTime agentTime;
+  final String prompt;
+  final String? response;
+  final DateTime? promptTimestamp;
+  final DateTime? responseTimestamp;
 
   Exchange({
-    required this.user,
-    required this.agent,
-    required this.userTime,
-    required this.agentTime,
+    required this.prompt,
+    required this.promptTimestamp,
+    this.response,
+    this.responseTimestamp,
   });
 }

--- a/lib/services/json_loader.dart
+++ b/lib/services/json_loader.dart
@@ -47,46 +47,54 @@ Conversation _parseConversation(Map raw) {
       ? DateTime.fromMillisecondsSinceEpoch((tsSeconds * 1000).toInt())
       : DateTime.now();
   final mapping = raw['mapping'] as Map? ?? {};
-  final exchanges = <Exchange>[];
-
+  final messages = <Map>[];
   for (final node in mapping.values) {
     if (node is Map) {
-      final message = node['message'];
-      if (message is Map) {
-        final author = message['author'];
-        if (author is Map && author['role'] == 'user') {
-          final children = node['children'];
-          if (children is List && children.isNotEmpty) {
-            final child = mapping[children.first];
-            if (child is Map) {
-              final childMsg = child['message'];
-              if (childMsg is Map) {
-                final childAuthor = childMsg['author'];
-                if (childAuthor is Map && childAuthor['role'] == 'assistant') {
-                  final userText = _extractText(message);
-                  final agentText = _extractText(childMsg);
-                  final userTimeSeconds = message['create_time'];
-                  final agentTimeSeconds = childMsg['create_time'];
-                  final userTime = userTimeSeconds is num
-                      ? DateTime.fromMillisecondsSinceEpoch(
-                          (userTimeSeconds * 1000).toInt())
-                      : ts;
-                  final agentTime = agentTimeSeconds is num
-                      ? DateTime.fromMillisecondsSinceEpoch(
-                          (agentTimeSeconds * 1000).toInt())
-                      : userTime;
-                  exchanges.add(Exchange(
-                    user: userText,
-                    agent: agentText,
-                    userTime: userTime,
-                    agentTime: agentTime,
-                  ));
-                }
-              }
-            }
-          }
+      final msg = node['message'];
+      if (msg is Map) messages.add(msg);
+    }
+  }
+
+  messages.sort((a, b) {
+    final at = a['create_time'];
+    final bt = b['create_time'];
+    if (at is num && bt is num) return at.compareTo(bt);
+    return 0;
+  });
+
+  final exchanges = <Exchange>[];
+  for (int i = 0; i < messages.length; i++) {
+    final msg = messages[i];
+    final author = msg['author'];
+    if (author is Map && author['role'] == 'user') {
+      final promptText = _extractText(msg);
+      final promptSec = msg['create_time'];
+      final promptTime = promptSec is num
+          ? DateTime.fromMillisecondsSinceEpoch((promptSec * 1000).toInt())
+          : null;
+
+      String? responseText;
+      DateTime? responseTime;
+
+      if (i + 1 < messages.length) {
+        final nextMsg = messages[i + 1];
+        final nextAuthor = nextMsg['author'];
+        if (nextAuthor is Map && nextAuthor['role'] == 'assistant') {
+          responseText = _extractText(nextMsg);
+          final respSec = nextMsg['create_time'];
+          responseTime = respSec is num
+              ? DateTime.fromMillisecondsSinceEpoch((respSec * 1000).toInt())
+              : null;
+          i++; // skip assistant
         }
       }
+
+      exchanges.add(Exchange(
+        prompt: promptText,
+        promptTimestamp: promptTime,
+        response: responseText,
+        responseTimestamp: responseTime,
+      ));
     }
   }
 

--- a/lib/widgets/conversation_view.dart
+++ b/lib/widgets/conversation_view.dart
@@ -50,12 +50,13 @@ class ConversationView extends StatelessWidget {
       children: [
         Padding(
           padding: const EdgeInsets.only(left: 8.0, bottom: 4.0),
-          child: Text('User : ${ex.user.replaceAll("\r", "")}') ,
+          child: Text('User : ${ex.prompt.replaceAll("\r", "")}'),
         ),
-        Padding(
-          padding: const EdgeInsets.only(left: 24.0, bottom: 4.0),
-          child: Text('Agent : ${ex.agent.replaceAll("\r", "")}'),
-        ),
+        if (ex.response != null)
+          Padding(
+            padding: const EdgeInsets.only(left: 24.0, bottom: 4.0),
+            child: Text('Agent : ${ex.response!.replaceAll("\r", "")}'),
+          ),
         const Divider(height: 16),
       ],
     );


### PR DESCRIPTION
## Summary
- add new `Exchange` data model for prompt/response pairs
- refactor JSON parsing to build `Exchange` entries sequentially
- update conversation view to render exchanges via new fields
- log Codex activity

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687d5fc8726883218252ecbd1e3df7d9