### PR TITLE
Add placeholder ConversationPanel widget

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -69,3 +69,4 @@ This file records all Codex-generated changes and implementations in this projec
 [250721hhmm][f37ba41][FTR][REF] Added Exchange object to encapsulate prompt-response pairs, updated JSON parsing and view logic
 [250721hhmm][aaaece][DOC][SNC] Restructured TASKS.md and reorganized roadmap
 [250721hhmm][c047c3][SNC][DOC] Added structured tasks for conversation list UI implementation and updated CURRENT_CONTEXT.md to reflect active work
+[2507212230][339de53][FTR][UI] Added ConversationPanel widget with placeholder layout and integrated into main UI

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'models/conversation.dart';
 import 'services/json_loader.dart';
 import 'widgets/conversation_view.dart';
+import 'widgets/conversation_panel.dart';
 import 'widgets/menu_bar.dart';
 import 'widgets/error_panel.dart';
 
@@ -59,6 +60,7 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   List<Conversation>? _conversations;
+  Conversation? _selectedConversation;
   bool _loading = false;
   String? _error;
   Future<void> _openJsonFile() async {
@@ -79,6 +81,7 @@ class _HomePageState extends State<HomePage> {
         final convs = await JsonLoader.loadConversations(file.path);
         setState(() {
           _conversations = convs;
+          _selectedConversation = null;
           _loading = false;
         });
       } on JsonLoadException catch (e) {
@@ -103,7 +106,18 @@ class _HomePageState extends State<HomePage> {
     } else if (_error != null) {
       body = ErrorPanel(message: _error!);
     } else if (_conversations != null) {
-      body = ConversationView(conversations: _conversations!);
+      body = Row(
+        children: [
+          Expanded(
+            flex: 1,
+            child: ConversationView(conversations: _conversations!),
+          ),
+          Expanded(
+            flex: 2,
+            child: ConversationPanel(conversation: _selectedConversation),
+          ),
+        ],
+      );
     } else {
       body = const Center(child: Text('Welcome to Colog V3'));
     }

--- a/lib/widgets/conversation_panel.dart
+++ b/lib/widgets/conversation_panel.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+import '../models/conversation.dart';
+
+class ConversationPanel extends StatelessWidget {
+  final Conversation? conversation;
+  const ConversationPanel({super.key, this.conversation});
+
+  @override
+  Widget build(BuildContext context) {
+    if (conversation == null) {
+      return const Center(child: Text('No conversation selected'));
+    }
+
+    return Container(
+      color: Theme.of(context).colorScheme.background,
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Text(
+          'ConversationPanel Loaded: ${conversation!.exchanges.length} exchanges',
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `ConversationPanel` widget with a placeholder message
- add `ConversationPanel` to the main layout alongside the conversation list
- log the addition in `CODEXLOG_CURRENT.md`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687d6d8af5d4832185ba431d12fcdc87