### PR TITLE
Link ConversationPanel to selection

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -76,3 +76,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507202330][1644128][REF][UI] Styled prompt and response sections with indentation and background differentiation
 
 [2507212342][bd269b][FTR][UI] Added two-line prompt/response summary preview for collapsed exchanges
+[2507202355][ec794b][FTR][UI] Linked ConversationPanel to update based on selected conversation from sidebar

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'models/conversation.dart';
 import 'services/json_loader.dart';
-import 'widgets/conversation_view.dart';
+import 'widgets/conversation_list.dart';
 import 'widgets/conversation_panel.dart';
 import 'widgets/menu_bar.dart';
 import 'widgets/error_panel.dart';
@@ -110,7 +110,15 @@ class _HomePageState extends State<HomePage> {
         children: [
           Expanded(
             flex: 1,
-            child: ConversationView(conversations: _conversations!),
+            child: ConversationList(
+              conversations: _conversations!,
+              selected: _selectedConversation,
+              onSelected: (c) {
+                setState(() {
+                  _selectedConversation = c;
+                });
+              },
+            ),
           ),
           Expanded(
             flex: 2,

--- a/lib/widgets/conversation_list.dart
+++ b/lib/widgets/conversation_list.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import '../models/conversation.dart';
+
+class ConversationList extends StatelessWidget {
+  final List<Conversation> conversations;
+  final Conversation? selected;
+  final ValueChanged<Conversation> onSelected;
+
+  const ConversationList({
+    super.key,
+    required this.conversations,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return ListView.builder(
+      itemCount: conversations.length,
+      itemBuilder: (context, index) {
+        final conv = conversations[index];
+        final selectedConv = conv == selected;
+        return Material(
+          color: selectedConv
+              ? colorScheme.primary.withOpacity(0.2)
+              : Colors.transparent,
+          child: InkWell(
+            onTap: () => onSelected(conv),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+              child: Text(
+                conv.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `ConversationList` widget to display selectable conversation titles
- update `HomePage` to use `ConversationList` and pass selected conversation to `ConversationPanel`
- document log entry

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687d815a97548321aaca978b95857220