### PR TITLE
Reset ConversationPanel scroll on selection

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -77,3 +77,4 @@ This file records all Codex-generated changes and implementations in this projec
 
 [2507212342][bd269b][FTR][UI] Added two-line prompt/response summary preview for collapsed exchanges
 [2507202355][ec794b][FTR][UI] Linked ConversationPanel to update based on selected conversation from sidebar
+[2507210002][e6de5e][FTR][UI] Reset scroll position to top when switching conversations in ConversationPanel

--- a/lib/widgets/conversation_panel.dart
+++ b/lib/widgets/conversation_panel.dart
@@ -14,14 +14,24 @@ class ConversationPanel extends StatefulWidget {
 class _ConversationPanelState extends State<ConversationPanel>
     with TickerProviderStateMixin {
   final Set<int> _expanded = <int>{};
+  final ScrollController _scrollController = ScrollController();
   static const promptBg = Color(0xFF0D47A1); // dark blue
   static const responseBg = Color(0xFF424242); // dark grey
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   @override
   void didUpdateWidget(covariant ConversationPanel oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.conversation != widget.conversation) {
       _expanded.clear();
+      if (_scrollController.hasClients) {
+        _scrollController.jumpTo(0);
+      }
     }
   }
 
@@ -42,6 +52,7 @@ class _ConversationPanelState extends State<ConversationPanel>
     return Container(
       color: colorScheme.background,
       child: ListView.builder(
+        controller: _scrollController,
         padding: const EdgeInsets.all(16),
         itemCount: exchanges.length,
         itemBuilder: (context, index) {


### PR DESCRIPTION
## Summary
- ensure ConversationPanel scrolls to the top when a new conversation is selected
- keep expand/collapse logic intact
- log update

## Testing
- `dart format lib/widgets/conversation_panel.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687d830585f08321a7611787b4747c10