### PR TITLE
Implement per-conversation expanded state

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -79,3 +79,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507202355][ec794b][FTR][UI] Linked ConversationPanel to update based on selected conversation from sidebar
 [2507210002][e6de5e][FTR][UI] Reset scroll position to top when switching conversations in ConversationPanel
 [250721hhmm][20824a8][REF][UI] Styled ConversationPanel scrollbar to match sidebar and ensured responsive scrolling
+[2507210113][e2fc9a][FTR][UI] Preserved per-conversation expand/collapse state in ConversationPanel

--- a/lib/widgets/conversation_panel.dart
+++ b/lib/widgets/conversation_panel.dart
@@ -13,10 +13,20 @@ class ConversationPanel extends StatefulWidget {
 
 class _ConversationPanelState extends State<ConversationPanel>
     with TickerProviderStateMixin {
-  final Set<int> _expanded = <int>{};
+  final Map<String, Set<int>> _expandedMap = <String, Set<int>>{};
+  Set<int> _expanded = <int>{};
   final ScrollController _scrollController = ScrollController();
   static const promptBg = Color(0xFF0D47A1); // dark blue
   static const responseBg = Color(0xFF424242); // dark grey
+
+  @override
+  void initState() {
+    super.initState();
+    final conv = widget.conversation;
+    if (conv != null) {
+      _expanded = _expandedMap[_keyFor(conv)] ?? <int>{};
+    }
+  }
 
   @override
   void dispose() {
@@ -28,7 +38,14 @@ class _ConversationPanelState extends State<ConversationPanel>
   void didUpdateWidget(covariant ConversationPanel oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.conversation != widget.conversation) {
-      _expanded.clear();
+      final oldConv = oldWidget.conversation;
+      if (oldConv != null) {
+        _expandedMap[_keyFor(oldConv)] = _expanded;
+      }
+      final newConv = widget.conversation;
+      _expanded = newConv != null
+          ? (_expandedMap[_keyFor(newConv)] ?? <int>{})
+          : <int>{};
       if (_scrollController.hasClients) {
         _scrollController.jumpTo(0);
       }
@@ -175,4 +192,7 @@ Widget build(BuildContext context) {
       ],
     );
   }
+
+  String _keyFor(Conversation conv) =>
+      '${conv.title}_${conv.timestamp.millisecondsSinceEpoch}';
 }


### PR DESCRIPTION
## Summary
- preserve per-conversation expand/collapse state in `ConversationPanel`
- update activity log

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687d93be110c8321b92d3f5ffb51b4b0