### PR TITLE
Implement styled conversation list layout

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -80,5 +80,5 @@ This file records all Codex-generated changes and implementations in this projec
 [2507210002][e6de5e][FTR][UI] Reset scroll position to top when switching conversations in ConversationPanel
 [250721hhmm][20824a8][REF][UI] Styled ConversationPanel scrollbar to match sidebar and ensured responsive scrolling
 [2507210113][e2fc9a][FTR][UI] Preserved per-conversation expand/collapse state in ConversationPanel
-
 [2507210143][60c9570][REF][PERF] Optimized ConversationPanel rendering with lazy ListView.builder for large conversations
+[2507210352][366d9e7][REF][UI] Styled conversation list with vertical index box, stacked title and metadata rows, and enhanced layout

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -87,6 +87,17 @@ class _HomePageState extends State<HomePage> {
       });
       try {
         final convs = await JsonLoader.loadConversations(file.path);
+        convs.sort((a, b) {
+          DateTime getLast(Conversation c) {
+            DateTime? ts;
+            for (final ex in c.exchanges) {
+              ts = ex.responseTimestamp ?? ex.promptTimestamp ?? ts;
+            }
+            return ts ?? c.timestamp;
+          }
+
+          return getLast(b).compareTo(getLast(a));
+        });
         setState(() {
           _conversations = convs;
           _selectedConversation = null;

--- a/lib/widgets/conversation_list.dart
+++ b/lib/widgets/conversation_list.dart
@@ -22,6 +22,15 @@ class ConversationList extends StatelessWidget {
       itemBuilder: (context, index) {
         final conv = conversations[index];
         final selectedConv = conv == selected;
+        final metaStyle = Theme.of(context)
+            .textTheme
+            .bodySmall
+            ?.copyWith(color: Colors.grey.shade400);
+
+        final lastUpdated = _lastUpdate(conv);
+        final metaText =
+            '${conv.exchanges.length} exchanges • Last updated $lastUpdated';
+
         return Material(
           color: selectedConv
               ? colorScheme.primary.withOpacity(0.2)
@@ -29,11 +38,46 @@ class ConversationList extends StatelessWidget {
           child: InkWell(
             onTap: () => onSelected(conv),
             child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
-              child: Text(
-                conv.title,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    height: 40,
+                    width: 24,
+                    margin: const EdgeInsets.symmetric(vertical: 2),
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: const Color(0xFFB8860B), // dark gold
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: Text('${index + 1}',
+                        style: Theme.of(context)
+                            .textTheme
+                            .bodySmall
+                            ?.copyWith(fontWeight: FontWeight.bold)),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          conv.title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          metaText,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: metaStyle,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
               ),
             ),
           ),
@@ -41,4 +85,13 @@ class ConversationList extends StatelessWidget {
       },
     );
   }
+}
+
+String _lastUpdate(Conversation c) {
+  DateTime? ts;
+  for (final ex in c.exchanges) {
+    ts = ex.responseTimestamp ?? ex.promptTimestamp ?? ts;
+  }
+  ts ??= c.timestamp;
+  return '${ts.year}-${ts.month.toString().padLeft(2, '0')}-${ts.day.toString().padLeft(2, '0')}';
 }


### PR DESCRIPTION
## Summary
- redesign `ConversationList` with index box and metadata line per entry
- sort conversations by last updated date on load
- log refactor

## Testing
- `dart`/`flutter` commands not available

------
https://chatgpt.com/codex/tasks/task_b_687db91793a08321b2b42318cf656ec9