### PR TITLE
Fix final exchange response rendering

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -82,3 +82,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507210113][e2fc9a][FTR][UI] Preserved per-conversation expand/collapse state in ConversationPanel
 [2507210143][60c9570][REF][PERF] Optimized ConversationPanel rendering with lazy ListView.builder for large conversations
 [2507210352][366d9e7][REF][UI] Styled conversation list with vertical index box, stacked title and metadata rows, and enhanced layout
+[2507210436][f33617][BUG][UI] Fixed missing response rendering for last exchange

--- a/lib/services/json_loader.dart
+++ b/lib/services/json_loader.dart
@@ -76,8 +76,9 @@ Conversation _parseConversation(Map raw) {
       String? responseText;
       DateTime? responseTime;
 
-      if (i + 1 < messages.length) {
-        final nextMsg = messages[i + 1];
+      int j = i + 1;
+      while (j < messages.length) {
+        final nextMsg = messages[j];
         final nextAuthor = nextMsg['author'];
         if (nextAuthor is Map && nextAuthor['role'] == 'assistant') {
           responseText = _extractText(nextMsg);
@@ -85,8 +86,14 @@ Conversation _parseConversation(Map raw) {
           responseTime = respSec is num
               ? DateTime.fromMillisecondsSinceEpoch((respSec * 1000).toInt())
               : null;
-          i++; // skip assistant
+          i = j; // skip up to assistant message
+          break;
+        } else if (nextAuthor is Map && nextAuthor['role'] == 'user') {
+          // Next user message found before an assistant response
+          i = j - 1; // adjust for loop increment
+          break;
         }
+        j++;
       }
 
       exchanges.add(Exchange(


### PR DESCRIPTION
## Summary
- fix pairing logic in JSON parser to ensure last exchange response is captured
- update activity log

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_687dc31e34ac8321802f664f85c20dab