### PR TITLE
Adjust index box color

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -83,3 +83,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507210143][60c9570][REF][PERF] Optimized ConversationPanel rendering with lazy ListView.builder for large conversations
 [2507210352][366d9e7][REF][UI] Styled conversation list with vertical index box, stacked title and metadata rows, and enhanced layout
 [2507210436][f33617][BUG][UI] Fixed missing response rendering for last exchange
+[2507210816][b2c7c7b][REF][UI] Updated index box color to medium-bright blue for improved readability

--- a/lib/widgets/conversation_list.dart
+++ b/lib/widgets/conversation_list.dart
@@ -48,7 +48,7 @@ class ConversationList extends StatelessWidget {
                     margin: const EdgeInsets.symmetric(vertical: 2),
                     alignment: Alignment.center,
                     decoration: BoxDecoration(
-                      color: const Color(0xFFB8860B), // dark gold
+                      color: const Color(0xFF1976D2), // medium-bright blue
                       borderRadius: BorderRadius.circular(4),
                     ),
                     child: Text('${index + 1}',


### PR DESCRIPTION
## Summary
- update conversation index box to medium-bright blue
- log update

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687df6e2ca94832193f2890b234803e3