### PR TITLE
Normalize expanded view font sizes

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -84,3 +84,5 @@ This file records all Codex-generated changes and implementations in this projec
 [2507210352][366d9e7][REF][UI] Styled conversation list with vertical index box, stacked title and metadata rows, and enhanced layout
 [2507210436][f33617][BUG][UI] Fixed missing response rendering for last exchange
 [2507210816][b2c7c7b][REF][UI] Updated index box color to medium-bright blue for improved readability
+
+[250721hhmm][8fe075][BUG][UI] Normalized prompt and response font sizes in expanded exchange views

--- a/lib/widgets/conversation_panel.dart
+++ b/lib/widgets/conversation_panel.dart
@@ -192,7 +192,7 @@ class _ExchangeTile extends StatelessWidget {
             maxLines: null,
             style: Theme.of(context)
                 .textTheme
-                .bodyLarge
+                .bodySmall
                 ?.copyWith(
                   fontWeight: FontWeight.bold,
                   color: Colors.grey.shade300,
@@ -213,7 +213,7 @@ class _ExchangeTile extends StatelessWidget {
               maxLines: null,
               style: Theme.of(context)
                   .textTheme
-                  .bodyMedium
+                  .bodySmall
                   ?.copyWith(
                     color: Colors.grey.shade200,
                   ),


### PR DESCRIPTION
## Summary
- ensure prompt and response share the same font size when an exchange is expanded
- update Codex log

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687df85dd6708321bee4416cafdce4b8