### PR TITLE
Refine expand/collapse animation

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -89,3 +89,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507210830][1a9ec7][REF][UI] Refined expand/collapse animations to anchor on prompt and animate content downward/upward naturally
 
 [2507210854][d478ecf][BUG][UI] Fixed last exchange skipping response rendering in both collapsed and expanded views
+[2507210907][a15feb][REF][UI] Added section-aware expand/collapse animations anchored to tapped region


### PR DESCRIPTION
## Summary
- adapt exchange tiles so tapping prompt anchors animation at the top
- allow tapping response to expand upward by anchoring to the bottom
- preserve scroll position during expansion
- log new behaviour

## Testing
- `dart --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_687e024f66608321ba451360a8def1ec