### PR TITLE
Archive old tasks & add atomic task files

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -91,3 +91,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507210854][d478ecf][BUG][UI] Fixed last exchange skipping response rendering in both collapsed and expanded views
 [2507210907][a15feb][REF][UI] Added section-aware expand/collapse animations anchored to tapped region
 [2507212237][1b897a5][DOC][SNC] Updated context and tasks
+[2507220542][bbf5e8f][SNC][DOC] Archived TASKS.md and moved tasks into atomic task sets

--- a/TASKS_OLD_220725.md
+++ b/TASKS_OLD_220725.md
@@ -1,0 +1,68 @@
+> ⚠️ This file has been archived as of 2025-07-22.  
+> It reflects an outdated monolithic task system and **must not** be used for future task tracking.  
+> All new development tasks are tracked under atomic task sets in the `tasks/` folder.
+
+# TASKS
+
+## ✅ Completed
+- Placeholder for completed tasks
+- Add initial Flutter app skeleton
+- Implement file selection and JSON preview
+- Display scrollable conversation and exchange views
+- Integrate custom JSON parser for ChatGPT export format
+- Build dynamic mapping of JSON into Exchanges grouped by Conversation
+- Apply dark theme styling throughout
+- Add conversation list header panel with labels
+- App opens in dark mode with menu bar and File > Open/Exit
+- Left panel lists conversations with index, title, exchange count, and timestamp
+- Clicking a conversation highlights it and populates the right panel with exchanges
+- Clicking an exchange expands/collapses to show full text
+- Dark theme with distinct colors and white fonts for readability
+
+
+## 🕰️ Legacy Tasks (Pre-UI Redesign)
+- Set up initial project structure and documentation
+- Define build and run scripts
+
+- Support toggleable expand/collapse per Exchange
+- Preserve expand state and scroll position
+- Automatically summarize exchanges and infer tags
+- Support multi-conversation JSON files
+- Implement full-text search and filter UI
+- Add summary sidebar with clickable exchange navigation
+- Add tag-based filtering with interactive labels
+- Implement tag label interactivity
+- Format Exchange prompt and response sections
+- Display preview summary lines per exchange
+- Indent responses in a wrapper panel
+- Show exchange counts in conversation rows
+
+## 🔜 Upcoming
+- Implement expandable Exchange panels that toggle on click
+- Add hover-based action icons (e.g., summarize, collapse) on Exchange containers
+- Visually delineate prompt/response pairs using background color and indentation
+- Create a collapsible left sidebar for browsing collapsed conversation titles
+- Add responsive layout with central content column and left/right padding
+- Enable fast, smooth scrolling for large conversation files
+- Display styled inline error panel on JSON parse failure (non-blocking)
+- Integrate Exchange rendering using parsed Exchange model objects
+- Preserve escape characters in rendered text (e.g., newlines shown correctly)
+- Load and render full conversations from large JSON files efficiently
+- Render a vertical, scrollable list of conversations in the left panel
+- Display conversation metadata (index, timestamp, title) using two-line layout
+- Add divider lines beneath each conversation entry for visual separation
+- Remove left border; use smart spacing for visual cleanliness
+- Highlight the selected conversation on click by inverting colors
+- Ensure only one conversation is highlighted at a time (de-highlight others)
+- Keep the selected conversation visually pinned during scroll
+- Deselect conversation via right-click
+- Add right-click context menu to conversation entries with:
+  - Custom<Clicked Element> stubbed function
+  - About stubbed function
+- Show the selected conversation's prompt/response view in the right panel
+- Ensure left and right panels scroll independently
+- Fix missing response display in exchanges
+- Improve expand/collapse animations to feel more natural and anchored
+- Add 3-dot hover menu to conversation labels and exchanges
+- Implement context menu triggered by 3-dot menu with single “About” option
+- Create “About” dialog with app name, version, author, and copyright

--- a/tasks/ui_debug/TASKS_ui_debug.md
+++ b/tasks/ui_debug/TASKS_ui_debug.md
@@ -1,0 +1,20 @@
+# TASKS_ui_debug.md
+
+## 🧱 UI Debugging Tasks (2025-07-22)
+
+This task file addresses immediate issues in the conversation and exchange display system.
+
+---
+
+### ✅ [IN SCOPE]
+
+1. **Fix missing responses in exchanges**  
+   Ensure responses render correctly for all exchanges, including first, last, and any in between.
+
+2. **Refine expand/collapse animation**  
+   Anchor animations smoothly from the tapped element and reduce layout shift. Ensure consistent experience across all exchanges.
+
+---
+
+### 📎 Context
+See `CURRENT_CONTEXT.md` for the current UI focus.

--- a/tasks/ui_hover_dot_menu/TASKS_ui_hover_dot_menu.md
+++ b/tasks/ui_hover_dot_menu/TASKS_ui_hover_dot_menu.md
@@ -1,0 +1,23 @@
+# TASKS_ui_hover_dot_menu.md
+
+## 🧩 Hover Dot Menu Implementation (2025-07-22)
+
+This task file introduces the contextual 3-dot menu for conversations and exchanges.
+
+---
+
+### ✅ [IN SCOPE]
+
+1. **Implement hover-activated 3-dot menu**  
+   Show 3-dot menu on hover over:
+   - Each conversation in the sidebar
+   - Each prompt/response section
+
+2. **Add contextual menu with 'About' option**  
+   On clicking the 3-dot icon, show a small contextual popup with one item:
+   - "About" → opens a modal/dialog showing app name, version, author, and copyright.
+
+---
+
+### 📎 Context
+See `CURRENT_CONTEXT.md` for the active UI task roadmap.


### PR DESCRIPTION
## Summary
- archive existing task list as `TASKS_OLD_220725.md`
- add `tasks/ui_debug` and `tasks/ui_hover_dot_menu` task sets
- log the migration

## Testing
- `./android/gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_687f2417a33c8321a407423cb4d61684