### PR TITLE
Fix loader chain search for assistant responses

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -95,3 +95,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507220621][8f3b54][BUG][UI] Fixed response lookup to capture first assistant child in JsonLoader
 [2507220631][92fb41][TST][UI] Added debugPrint on exchange expand to log conversation, index, and prompt/response preview
 [2507220656][e4536e][BUG][REF] Fixed Exchange parsing to use full mapping and added placeholder fallback for missing prompt or response
+[2507220732][72f920][BUG][REF] Walked assistant response chain to find first non-empty assistant message for each exchange


### PR DESCRIPTION
## Summary
- track node ids in JsonLoader and walk child chain
- look for first non-empty assistant message via helper
- normalize exchanges when prompt or response missing
- update log

## Testing
- `flutter test` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687f3e0f17748321b7c420a606bf610e