### PR TITLE
Implement hover contextual menu

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -99,3 +99,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507220754][cc9e4f9][REF][UI] Added anchored expand/collapse animation for prompt and response blocks with directional logic
 [2507220806][9524b80][BUG][UI] Fixed response block expanding upward
 [2507220817][677d05f][SNC][DOC] Marked ui_debug tasks complete and updated CURRENT_CONTEXT.md to focus on UI hover menu implementation
+[2507221039][39153c][FTR][UI] Implemented hover-triggered 3-dot contextual menu with About dialog for conversations and exchanges

--- a/lib/widgets/conversation_list.dart
+++ b/lib/widgets/conversation_list.dart
@@ -21,70 +21,151 @@ class ConversationList extends StatelessWidget {
       itemCount: conversations.length,
       itemBuilder: (context, index) {
         final conv = conversations[index];
-        final selectedConv = conv == selected;
-        final metaStyle = Theme.of(context)
-            .textTheme
-            .bodySmall
-            ?.copyWith(color: Colors.grey.shade400);
-
-        final lastUpdated = _lastUpdate(conv);
-        final metaText =
-            '${conv.exchanges.length} exchanges • Last updated $lastUpdated';
-
-        return Material(
-          color: selectedConv
-              ? colorScheme.primary.withOpacity(0.2)
-              : Colors.transparent,
-          child: InkWell(
-            onTap: () => onSelected(conv),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Container(
-                    height: 40,
-                    width: 24,
-                    margin: const EdgeInsets.symmetric(vertical: 2),
-                    alignment: Alignment.center,
-                    decoration: BoxDecoration(
-                      color: const Color(0xFF1976D2), // medium-bright blue
-                      borderRadius: BorderRadius.circular(4),
-                    ),
-                    child: Text('${index + 1}',
-                        style: Theme.of(context)
-                            .textTheme
-                            .bodySmall
-                            ?.copyWith(fontWeight: FontWeight.bold)),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          conv.title,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        const SizedBox(height: 2),
-                        Text(
-                          metaText,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: metaStyle,
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
+        return _ConversationRow(
+          conversation: conv,
+          index: index,
+          selected: conv == selected,
+          onSelected: () => onSelected(conv),
         );
       },
     );
   }
+}
+
+class _ConversationRow extends StatefulWidget {
+  final Conversation conversation;
+  final int index;
+  final bool selected;
+  final VoidCallback onSelected;
+
+  const _ConversationRow({
+    required this.conversation,
+    required this.index,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  @override
+  State<_ConversationRow> createState() => _ConversationRowState();
+}
+
+class _ConversationRowState extends State<_ConversationRow> {
+  bool _hover = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final metaStyle = Theme.of(context)
+        .textTheme
+        .bodySmall
+        ?.copyWith(color: Colors.grey.shade400);
+
+    final lastUpdated = _lastUpdate(widget.conversation);
+    final metaText =
+        '${widget.conversation.exchanges.length} exchanges • Last updated $lastUpdated';
+
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hover = true),
+      onExit: (_) => setState(() => _hover = false),
+      child: Material(
+        color: widget.selected
+            ? colorScheme.primary.withOpacity(0.2)
+            : Colors.transparent,
+        child: InkWell(
+          onTap: widget.onSelected,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  height: 40,
+                  width: 24,
+                  margin: const EdgeInsets.symmetric(vertical: 2),
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF1976D2), // medium-bright blue
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text('${widget.index + 1}',
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodySmall
+                          ?.copyWith(fontWeight: FontWeight.bold)),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        widget.conversation.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        metaText,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: metaStyle,
+                      ),
+                    ],
+                  ),
+                ),
+                AnimatedOpacity(
+                  opacity: _hover ? 1 : 0,
+                  duration: const Duration(milliseconds: 150),
+                  child: PopupMenuButton<String>(
+                    icon: const Icon(Icons.more_vert, size: 20),
+                    color: Theme.of(context).colorScheme.surface,
+                    onSelected: (value) {
+                      if (value == 'about') {
+                        _showAboutDialog(context);
+                      }
+                    },
+                    itemBuilder: (context) => [
+                      const PopupMenuItem(
+                        value: 'about',
+                        child: Text('About'),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+void _showAboutDialog(BuildContext context) {
+  showDialog(
+    context: context,
+    builder: (context) {
+      return AlertDialog(
+        title: const Text('About'),
+        content: const Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('App Name: Colog V3'),
+            Text('Version: 0.1.0'),
+            Text('Author: Charles Clark'),
+            Text('© 2025'),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      );
+    },
+  );
 }
 
 String _lastUpdate(Conversation c) {

--- a/lib/widgets/conversation_panel.dart
+++ b/lib/widgets/conversation_panel.dart
@@ -209,6 +209,8 @@ class _ExchangeTile extends StatefulWidget {
 class _ExchangeTileState extends State<_ExchangeTile>
     with TickerProviderStateMixin {
   bool? expandedFromPrompt;
+  bool _hoverPrompt = false;
+  bool _hoverResponse = false;
 
   void _toggleFromPrompt() {
     setState(() {
@@ -247,50 +249,78 @@ class _ExchangeTileState extends State<_ExchangeTile>
     final lines = widget.exchange.prompt.split('\n');
     final first = lines.first;
     final rest = lines.length > 1 ? lines.sublist(1).join('\n') : '';
-    return GestureDetector(
-      onTap: _toggleFromPrompt,
-      child: Container(
-        padding: const EdgeInsets.all(12),
-        decoration: BoxDecoration(
-          color: _ConversationPanelState.promptBg,
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hoverPrompt = true),
+      onExit: (_) => setState(() => _hoverPrompt = false),
+      child: GestureDetector(
+        onTap: _toggleFromPrompt,
+        child: Stack(
           children: [
             Container(
-              key: widget.promptKey,
-              alignment: Alignment.centerLeft,
-              child: Text(
-                first,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      fontWeight: FontWeight.bold,
-                      color: Colors.grey.shade300,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: _ConversationPanelState.promptBg,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    key: widget.promptKey,
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      first,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: Colors.grey.shade300,
+                          ),
                     ),
+                  ),
+                  AnimatedSize(
+                    alignment: Alignment.topCenter,
+                    duration: const Duration(milliseconds: 250),
+                    curve: Curves.easeInOut,
+                    child: expand && rest.isNotEmpty
+                        ? Padding(
+                            padding: const EdgeInsets.only(top: 4),
+                            child: Text(
+                              rest,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodySmall
+                                  ?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                    color: Colors.grey.shade300,
+                                  ),
+                            ),
+                          )
+                        : const SizedBox.shrink(),
+                  ),
+                ],
               ),
             ),
-            AnimatedSize(
-              alignment: Alignment.topCenter,
-              duration: const Duration(milliseconds: 250),
-              curve: Curves.easeInOut,
-              child: expand && rest.isNotEmpty
-                  ? Padding(
-                      padding: const EdgeInsets.only(top: 4),
-                      child: Text(
-                        rest,
-                        style: Theme.of(context)
-                            .textTheme
-                            .bodySmall
-                            ?.copyWith(
-                              fontWeight: FontWeight.bold,
-                              color: Colors.grey.shade300,
-                            ),
-                      ),
-                    )
-                  : const SizedBox.shrink(),
+            Positioned(
+              top: 0,
+              right: 0,
+              child: AnimatedOpacity(
+                opacity: _hoverPrompt ? 1 : 0,
+                duration: const Duration(milliseconds: 150),
+                child: PopupMenuButton<String>(
+                  icon: const Icon(Icons.more_vert, size: 20),
+                  color: Theme.of(context).colorScheme.surface,
+                  onSelected: (value) {
+                    if (value == 'about') {
+                      _showAboutDialog(context);
+                    }
+                  },
+                  itemBuilder: (context) => [
+                    const PopupMenuItem(value: 'about', child: Text('About')),
+                  ],
+                ),
+              ),
             ),
           ],
         ),
@@ -303,56 +333,111 @@ class _ExchangeTileState extends State<_ExchangeTile>
     final first = lines.first;
     final rest = lines.length > 1 ? lines.sublist(1).join('\n') : '';
 
-    return GestureDetector(
-      onTap: _toggleFromResponse,
-      child: Container(
-        margin: const EdgeInsets.only(left: 16),
-        padding: const EdgeInsets.all(12),
-        decoration: BoxDecoration(
-          color: _ConversationPanelState.responseBg,
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hoverResponse = true),
+      onExit: (_) => setState(() => _hoverResponse = false),
+      child: GestureDetector(
+        onTap: _toggleFromResponse,
+        child: Stack(
           children: [
             Container(
-              key: widget.responseKey,
-              alignment: Alignment.centerLeft,
-              child: Text(
-                first,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: Theme.of(context)
-                    .textTheme
-                    .bodySmall
-                    ?.copyWith(
-                      color: Colors.grey.shade200,
+              margin: const EdgeInsets.only(left: 16),
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: _ConversationPanelState.responseBg,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    key: widget.responseKey,
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      first,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodySmall
+                          ?.copyWith(
+                            color: Colors.grey.shade200,
+                          ),
                     ),
+                  ),
+                  AnimatedSize(
+                    alignment: Alignment.topCenter,
+                    duration: const Duration(milliseconds: 250),
+                    curve: Curves.easeInOut,
+                    child: expand && rest.isNotEmpty
+                        ? Padding(
+                            padding: const EdgeInsets.only(top: 4),
+                            child: Text(
+                              rest,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodySmall
+                                  ?.copyWith(
+                                    color: Colors.grey.shade200,
+                                  ),
+                            ),
+                          )
+                        : const SizedBox.shrink(),
+                  ),
+                ],
               ),
             ),
-            AnimatedSize(
-              alignment: Alignment.topCenter,
-              duration: const Duration(milliseconds: 250),
-              curve: Curves.easeInOut,
-              child: expand && rest.isNotEmpty
-                  ? Padding(
-                      padding: const EdgeInsets.only(top: 4),
-                      child: Text(
-                        rest,
-                        style: Theme.of(context)
-                            .textTheme
-                            .bodySmall
-                            ?.copyWith(
-                              color: Colors.grey.shade200,
-                            ),
-                      ),
-                    )
-                  : const SizedBox.shrink(),
+            Positioned(
+              top: 0,
+              right: 0,
+              child: AnimatedOpacity(
+                opacity: _hoverResponse ? 1 : 0,
+                duration: const Duration(milliseconds: 150),
+                child: PopupMenuButton<String>(
+                  icon: const Icon(Icons.more_vert, size: 20),
+                  color: Theme.of(context).colorScheme.surface,
+                  onSelected: (value) {
+                    if (value == 'about') {
+                      _showAboutDialog(context);
+                    }
+                  },
+                  itemBuilder: (context) => [
+                    const PopupMenuItem(value: 'about', child: Text('About')),
+                  ],
+                ),
+              ),
             ),
           ],
         ),
       ),
     );
   }
+}
+
+void _showAboutDialog(BuildContext context) {
+  showDialog(
+    context: context,
+    builder: (context) {
+      return AlertDialog(
+        title: const Text('About'),
+        content: const Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('App Name: Colog V3'),
+            Text('Version: 0.1.0'),
+            Text('Author: Charles Clark'),
+            Text('© 2025'),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      );
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- add hover-activated 3-dot menu to conversation rows
- show contextual menu on exchanges with About dialog
- log hover menu implementation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687f69b4fb9c832191a4b15a7e4eb1ad