### PR TITLE
Add tasks for exporting context views

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -102,3 +102,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507221239][f7e2e3][DOC] Added iterative merging loop tasks
 [2507221237][3ccb04f][DOC] Added debug logging and state tracking tasks
 [2507221238][38fa76e][DOC] Added single exchange processor tasks
+[2507221243][1aa082c][DOC] Added export context tasks

--- a/tasks/milestone3/TASKS_export_context_to_multiple_views.md
+++ b/tasks/milestone3/TASKS_export_context_to_multiple_views.md
@@ -1,0 +1,20 @@
+# TASKS_export_context_to_multiple_views.md
+
+## 🌐 Export Context to Multiple Views
+
+These tasks define how conversation context can be exported in several formats for different audiences and tooling.
+
+---
+
+1. **Define export formats for:**
+   - High-fidelity conversation resume block (Markdown)
+   - Human-readable design or feature summary
+   - Structured JSON representation for downstream tooling
+2. **Create an exporter module with a pluggable output type interface.**
+3. **Ensure each view includes a header or footer with metadata and purpose.**
+4. **Write export test cases for each format using a sample ContextMemory.**
+
+---
+
+### 📎 Context
+This milestone introduces multiple export views so that context can be reused across documentation and automation workflows.


### PR DESCRIPTION
## Summary
- create milestone3 tasks for exporting context to multiple formats
- log the new tasks

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687f871d49b08321bc054a253c98f630