### PR TITLE
Add output routing milestone tasks

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -102,3 +102,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507221239][f7e2e3][DOC] Added iterative merging loop tasks
 [2507221237][3ccb04f][DOC] Added debug logging and state tracking tasks
 [2507221238][38fa76e][DOC] Added single exchange processor tasks
+[2507221243][6fbed01][DOC] Added extensible output routing tasks

--- a/tasks/milestone3/TASKS_define_extensible_output_routing.md
+++ b/tasks/milestone3/TASKS_define_extensible_output_routing.md
@@ -1,0 +1,8 @@
+1. Implement a router that takes the final ContextMemory and dispatches it to one or more destinations.
+2. Destinations include:
+   - File system (e.g., save to `context_memory/`)
+   - Log summary viewer (optional stub)
+   - Documentation generator (placeholder)
+   - Error/fix pattern archive (if applicable)
+3. Allow configuration of output routing via a settings file or CLI flags.
+4. Document how to add a new output target to the system.


### PR DESCRIPTION
## Summary
- set up milestone3 folder
- document extensible output routing tasks
- log task file addition

## Testing
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687f87244d7483218300f4fca8c6e6a0