### PR TITLE
Add CLI context build runner tasks

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -105,3 +105,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507221243][6fbed01][DOC] Added extensible output routing tasks
 [2507221244][afbea86][DOC] Added final context memory output tasks
 [2507221243][1aa082c][DOC] Added export context tasks
+[2507221251][3512291][DOC] Added CLI context build runner tasks

--- a/tasks/milestone4/TASKS_create_cli_context_build_runner.md
+++ b/tasks/milestone4/TASKS_create_cli_context_build_runner.md
@@ -1,0 +1,22 @@
+# TASKS_create_cli_context_build_runner.md
+
+## 🛠️ CLI Context Build Runner
+
+These tasks outline a command line tool for building ContextMemory from stored Exchanges.
+
+---
+
+1. **Implement a CLI entry point to trigger context memory building from a set of Exchanges.**
+2. **Support arguments for:**
+   - Input file or directory
+   - Output format (e.g., markdown, json)
+   - Start/end Exchange IDs (optional)
+   - Debug mode toggle
+3. **Show progress updates as Exchanges are processed.**
+4. **Log final memory output location and summary.**
+5. **Provide usage instructions and example invocations.**
+
+---
+
+### 📎 Context
+This milestone introduces tooling to run the memory builder outside the GUI.


### PR DESCRIPTION
## Summary
- add tasks for building context memory via CLI
- log the new tasks in CODEXLOG_CURRENT

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687f88f2fd9483219c66d6a6d56a3ad8