### PR TITLE
Add manual review tasks

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -105,3 +105,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507221243][6fbed01][DOC] Added extensible output routing tasks
 [2507221244][afbea86][DOC] Added final context memory output tasks
 [2507221243][1aa082c][DOC] Added export context tasks
+[2507221251][d40f6e][DOC] Added manual review and editing tasks

--- a/tasks/milestone4/TASKS_support_manual_review_and_editing.md
+++ b/tasks/milestone4/TASKS_support_manual_review_and_editing.md
@@ -1,0 +1,18 @@
+# TASKS_support_manual_review_and_editing.md
+
+## 📝 Manual Review and Editing Support (2025-07-22)
+
+This file lists tasks for enabling user review and inline editing of each LLM-generated `ContextParcel` before it becomes part of the final memory.
+
+---
+
+1. **Enable manual review of each LLM-generated `ContextParcel` before merging.**
+2. **Present a diff or preview of proposed changes to the user.**
+3. **Allow the user to accept, reject, or edit each delta inline.**
+4. **Store all accepted edits in the merge history.**
+5. **Add a config flag to enable or disable manual review mode.**
+
+---
+
+### 📎 Context
+See `CURRENT_CONTEXT.md` for current roadmap details.


### PR DESCRIPTION
## Summary
- add milestone4 doc file with tasks for manual review and editing of ContextParcels
- log the new documentation task

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687f88faaefc832185a3393cec4f81d9