### PR TITLE
Fix overflow of long lines in collapsed prompts

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -109,3 +109,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507221256][d50a76][DOC] Added feature module routing tasks
 [2507221256][ed7fe8][DOC] Added context role tagging tasks
 [2507232210][5ef516][FTR][UI] Added live search bar to conversation list panel and implemented case-insensitive substring filtering across prompts and responses
+[2507232222][5242f4][BUG][UI] Truncated long single-line prompt/response previews to one visual line in collapsed view using ellipsis

--- a/lib/widgets/conversation_panel.dart
+++ b/lib/widgets/conversation_panel.dart
@@ -151,8 +151,9 @@ Widget build(BuildContext context) {
             ex.prompt,
             style: _ConversationPanelState.textStyle
                 .copyWith(color: Colors.grey.shade300),
-            softWrap: true,
-            overflow: TextOverflow.visible,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            softWrap: false,
           ),
         ),
         if (ex.response != null)
@@ -169,8 +170,9 @@ Widget build(BuildContext context) {
                 ex.response!,
                 style: _ConversationPanelState.textStyle
                     .copyWith(color: Colors.grey.shade200),
-                softWrap: true,
-                overflow: TextOverflow.visible,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                softWrap: false,
               ),
             ),
           ),
@@ -274,8 +276,10 @@ class _ExchangeTileState extends State<_ExchangeTile>
                       first,
                       style: _ConversationPanelState.textStyle
                           .copyWith(color: Colors.grey.shade300),
-                      softWrap: true,
-                      overflow: TextOverflow.visible,
+                      maxLines: expand ? null : 1,
+                      overflow:
+                          expand ? TextOverflow.visible : TextOverflow.ellipsis,
+                      softWrap: expand,
                     ),
                   ),
                   AnimatedSize(
@@ -354,8 +358,10 @@ class _ExchangeTileState extends State<_ExchangeTile>
                       first,
                       style: _ConversationPanelState.textStyle
                           .copyWith(color: Colors.grey.shade200),
-                      softWrap: true,
-                      overflow: TextOverflow.visible,
+                      maxLines: expand ? null : 1,
+                      overflow:
+                          expand ? TextOverflow.visible : TextOverflow.ellipsis,
+                      softWrap: expand,
                     ),
                   ),
                   AnimatedSize(


### PR DESCRIPTION
## Summary
- limit collapsed prompt/response preview to one line using ellipsis
- update ExchangeTile blocks so collapsed text doesn't wrap
- log Codex activity

## Testing
- `flutter test` *(fails: Couldn't resolve the package 'cologv3')*

------
https://chatgpt.com/codex/tasks/task_b_68800ce00e7083219698bbea5c95b7c8