### PR TITLE
Add ContextParcel model

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -112,3 +112,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507232222][5242f4][BUG][UI] Truncated long single-line prompt/response previews to one visual line in collapsed view using ellipsis
 [2507222231][64b31f][FTR][UI] Added left panel status line showing file path, filtered/total conversation count, and current time
 [2507232249][5001bc][REF][UI] Moved status line to bottom of window and expanded layout to show file path, filtered/total conversation count, and system time
+[2507232255][50bf9e2][FTR][DATA] Added ContextParcel model with summary, metadata, tags, and confidence tracking

--- a/lib/models/context_parcel.dart
+++ b/lib/models/context_parcel.dart
@@ -1,0 +1,52 @@
+class ContextParcel {
+  /// Human-readable context summary for quick reference
+  final String summary;
+
+  /// IDs of exchanges that contributed to this summary
+  final List<int> contributingExchangeIds;
+
+  /// Optional manual or inferred tags (e.g. "bug", "feature")
+  final List<String> tags;
+
+  /// Optional assumptions inferred or explicitly stated
+  final List<String> assumptions;
+
+  /// Optional confidence values for parts of the summary or tags
+  final Map<String, double> confidence;
+
+  ContextParcel({
+    required this.summary,
+    required this.contributingExchangeIds,
+    this.tags = const [],
+    this.assumptions = const [],
+    this.confidence = const {},
+  });
+
+  factory ContextParcel.fromJson(Map<String, dynamic> json) => ContextParcel(
+        summary: json['summary'],
+        contributingExchangeIds: List<int>.from(json['contributingExchangeIds']),
+        tags: List<String>.from(json['tags'] ?? []),
+        assumptions: List<String>.from(json['assumptions'] ?? []),
+        confidence: Map<String, double>.from(json['confidence'] ?? {}),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'summary': summary,
+        'contributingExchangeIds': contributingExchangeIds,
+        'tags': tags,
+        'assumptions': assumptions,
+        'confidence': confidence,
+      };
+}
+
+/*
+Example:
+
+ContextParcel(
+  summary: "Discussed bug in message loader and implemented JSON streaming fix.",
+  contributingExchangeIds: [101, 102, 105],
+  tags: ["bug", "loader", "streaming"],
+  assumptions: ["File was too large for previous parser"],
+  confidence: {"summary": 0.95}
+);
+*/


### PR DESCRIPTION
## Summary
- add `ContextParcel` data model with JSON serialization and usage example
- log the addition

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68801679bc70832189687e6cef485ea5