### PR TITLE
Add ContextMemory model

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -113,3 +113,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507222231][64b31f][FTR][UI] Added left panel status line showing file path, filtered/total conversation count, and current time
 [2507232249][5001bc][REF][UI] Moved status line to bottom of window and expanded layout to show file path, filtered/total conversation count, and system time
 [2507232255][50bf9e2][FTR][DATA] Added ContextParcel model with summary, metadata, tags, and confidence tracking
+[2507232303][22e3b1][FTR][DATA] Added ContextMemory object to track latest and historical context parcels

--- a/lib/models/context_memory.dart
+++ b/lib/models/context_memory.dart
@@ -1,0 +1,43 @@
+import 'context_parcel.dart';
+
+class ContextMemory {
+  ContextParcel? current;
+  final List<ContextParcel> history;
+
+  ContextMemory({this.current, List<ContextParcel>? history})
+      : history = history ?? [];
+
+  void update(ContextParcel newParcel) {
+    if (current != null) {
+      history.add(current!);
+    }
+    current = newParcel;
+  }
+
+  void reset() {
+    current = null;
+    history.clear();
+  }
+
+  factory ContextMemory.fromJson(Map<String, dynamic> json) => ContextMemory(
+        current: json['current'] != null
+            ? ContextParcel.fromJson(json['current'])
+            : null,
+        history: (json['history'] as List<dynamic>?)
+            ?.map((e) => ContextParcel.fromJson(e))
+            .toList(),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'current': current?.toJson(),
+        'history': history.map((e) => e.toJson()).toList(),
+      };
+}
+
+/*
+Example usage:
+
+final memory = ContextMemory();
+memory.update(ContextParcel(...));
+print(memory.current?.summary);
+*/


### PR DESCRIPTION
## Summary
- add `ContextMemory` object to keep latest and historical context
- log the addition

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6880186575f083218d77942f597a9d88