### PR TITLE
Document merge history handling

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -116,3 +116,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507232303][22e3b1][FTR][DATA] Added ContextMemory object to track latest and historical context parcels
 [2507232311][333153][FTR][UI] Added index numbers to each prompt in right panel, styled similarly to conversation list and placed inside prompt box
 [2507222317][cef7c7][FTR][DATA] Added ContextDelta model to represent changes between context states
+[2507232325][0aa7d50][REF][DATA] Documented and clarified merge history handling in ContextMemory

--- a/lib/models/context_memory.dart
+++ b/lib/models/context_memory.dart
@@ -1,7 +1,18 @@
 import 'context_parcel.dart';
 
+/*
+Merge History Policy:
+
+- Each call to `update()` pushes the current context into `history`.
+- This preserves all prior full versions of merged context.
+- Deltas are not currently stored separately; only full snapshots are tracked.
+- Rollback and inspection of older context states is supported via `history`.
+*/
+
 class ContextMemory {
   ContextParcel? current;
+  // Stores prior full ContextParcel snapshots before each update.
+  // Allows rollback or inspection of previous merged states.
   final List<ContextParcel> history;
 
   ContextMemory({this.current, List<ContextParcel>? history})
@@ -17,6 +28,11 @@ class ContextMemory {
   void reset() {
     current = null;
     history.clear();
+  }
+
+  ContextParcel? getPrevious(int stepsBack) {
+    if (stepsBack < 1 || stepsBack > history.length) return null;
+    return history[history.length - stepsBack];
   }
 
   factory ContextMemory.fromJson(Map<String, dynamic> json) => ContextMemory(


### PR DESCRIPTION
## Summary
- clarify merge history policy in `ContextMemory`
- document the `history` list
- add `getPrevious` helper to retrieve an older `ContextParcel`
- update CODEX log

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*
- `./gradlew test --no-daemon` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68801d8e951c8321aefebdf62c3a86ea