### PR TITLE
Implement context merge strategies

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -118,3 +118,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507222317][cef7c7][FTR][DATA] Added ContextDelta model to represent changes between context states
 [2507232325][0aa7d50][REF][DATA] Documented and clarified merge history handling in ContextMemory
 [2507232338][6b805f][DOC][DATA] Added JSON schema examples to ContextParcel, ContextMemory, and ContextDelta models
+[2507222353][158a9d4][FTR][DATA] Implemented merge strategies with versioning

--- a/lib/models/context_memory.dart
+++ b/lib/models/context_memory.dart
@@ -1,4 +1,5 @@
 import 'context_parcel.dart';
+import 'merge_strategy.dart';
 
 /*
 Merge History Policy:
@@ -14,9 +15,22 @@ class ContextMemory {
   // Stores prior full ContextParcel snapshots before each update.
   // Allows rollback or inspection of previous merged states.
   final List<ContextParcel> history;
+  // Previous ContextMemory snapshots for versioning support.
+  final List<ContextMemory> versions;
 
-  ContextMemory({this.current, List<ContextParcel>? history})
-      : history = history ?? [];
+  // Default merging strategy when none provided.
+  MergeStrategy strategy;
+
+  DateTime? lastMerged;
+
+  ContextMemory({
+    this.current,
+    List<ContextParcel>? history,
+    this.strategy = MergeStrategy.appendWithRefinement,
+    List<ContextMemory>? versions,
+    this.lastMerged,
+  })  : history = history ?? [],
+        versions = versions ?? [];
 
   void update(ContextParcel newParcel) {
     if (current != null) {
@@ -25,9 +39,70 @@ class ContextMemory {
     current = newParcel;
   }
 
+  /// Merge [other] into this memory using [strategyOverride] if provided.
+  void mergeWith(ContextMemory other, {MergeStrategy? strategyOverride}) {
+    final strat = strategyOverride ?? strategy;
+    versions.add(clone());
+    lastMerged = DateTime.now();
+
+    final newParcels = <ContextParcel>[];
+    newParcels.addAll(other.history);
+    if (other.current != null) newParcels.add(other.current!);
+
+    for (final parcel in newParcels) {
+      switch (strat) {
+        case MergeStrategy.appendWithRefinement:
+          if (allParcels.any((p) => p.isRedundantWith(parcel))) {
+            continue;
+          }
+          if (current != null) history.add(current!);
+          current = parcel;
+          break;
+        case MergeStrategy.replaceOnConflict:
+          bool replaced = false;
+          for (var i = 0; i < history.length; i++) {
+            if (history[i].isRedundantWith(parcel)) {
+              history[i] = parcel;
+              replaced = true;
+              break;
+            }
+          }
+          if (!replaced && current != null && current!.isRedundantWith(parcel)) {
+            current = parcel;
+            replaced = true;
+          }
+          if (!replaced) {
+            if (current != null) history.add(current!);
+            current = parcel;
+          }
+          break;
+      }
+    }
+  }
+
+  /// Returns all stored parcels including history and current.
+  List<ContextParcel> get allParcels => [
+        ...history,
+        if (current != null) current!,
+      ];
+
+  /// Creates a deep copy of this memory.
+  ContextMemory clone() => ContextMemory(
+        current: current != null
+            ? ContextParcel.fromJson(current!.toJson())
+            : null,
+        history:
+            history.map((e) => ContextParcel.fromJson(e.toJson())).toList(),
+        strategy: strategy,
+        versions: versions.map((v) => v.clone()).toList(),
+        lastMerged: lastMerged,
+      );
+
   void reset() {
     current = null;
     history.clear();
+    versions.clear();
+    lastMerged = null;
   }
 
   ContextParcel? getPrevious(int stepsBack) {
@@ -40,13 +115,27 @@ class ContextMemory {
             ? ContextParcel.fromJson(json['current'])
             : null,
         history: (json['history'] as List<dynamic>?)
-            ?.map((e) => ContextParcel.fromJson(e))
-            .toList(),
+                ?.map((e) => ContextParcel.fromJson(e))
+                .toList() ??
+            [],
+        strategy: json['strategy'] != null
+            ? MergeStrategy.values.byName(json['strategy'])
+            : MergeStrategy.appendWithRefinement,
+        versions: (json['versions'] as List<dynamic>?)
+                ?.map((e) => ContextMemory.fromJson(e))
+                .toList() ??
+            [],
+        lastMerged: json['lastMerged'] != null
+            ? DateTime.parse(json['lastMerged'])
+            : null,
       );
 
   Map<String, dynamic> toJson() => {
         'current': current?.toJson(),
         'history': history.map((e) => e.toJson()).toList(),
+        'strategy': strategy.name,
+        'versions': versions.map((e) => e.toJson()).toList(),
+        'lastMerged': lastMerged?.toIso8601String(),
       };
 }
 
@@ -66,6 +155,9 @@ print(memory.current?.summary);
   "history": [
     { ...previous ContextParcel... },
     { ...older ContextParcel... }
-  ]
+  ],
+  "strategy": "appendWithRefinement",
+  "versions": [],
+  "lastMerged": "2025-07-23T22:13:00Z"
 }
 */

--- a/lib/models/context_parcel.dart
+++ b/lib/models/context_parcel.dart
@@ -37,6 +37,49 @@ class ContextParcel {
         'assumptions': assumptions,
         'confidence': confidence,
       };
+
+  /// Returns true if this parcel conveys essentially the same
+  /// information as [other] using simple text and tag comparisons.
+  bool isRedundantWith(ContextParcel other) {
+    final a = _normalize(summary);
+    final b = _normalize(other.summary);
+    if (a == b || a.contains(b) || b.contains(a)) return true;
+    if (_levenshtein(a, b) < 10) return true;
+
+    final tagsA = tags.map((e) => e.toLowerCase()).toSet();
+    final tagsB = other.tags.map((e) => e.toLowerCase()).toSet();
+    if (tagsA.isNotEmpty && tagsA.length == tagsB.length && tagsA.containsAll(tagsB)) {
+      return true;
+    }
+    return false;
+  }
+
+  String _normalize(String input) =>
+      input.toLowerCase().replaceAll(RegExp(r'\s+'), ' ').trim();
+
+  int _levenshtein(String s, String t) {
+    if (s == t) return 0;
+    if (s.isEmpty) return t.length;
+    if (t.isEmpty) return s.length;
+    final v0 = List<int>.generate(t.length + 1, (i) => i);
+    final v1 = List<int>.filled(t.length + 1, 0);
+
+    for (var i = 0; i < s.length; i++) {
+      v1[0] = i + 1;
+      for (var j = 0; j < t.length; j++) {
+        final cost = s[i] == t[j] ? 0 : 1;
+        v1[j + 1] = [
+          v1[j] + 1,
+          v0[j + 1] + 1,
+          v0[j] + cost,
+        ].reduce((a, b) => a < b ? a : b);
+      }
+      for (var j = 0; j < v0.length; j++) {
+        v0[j] = v1[j];
+      }
+    }
+    return v1[t.length];
+  }
 }
 
 /*

--- a/lib/models/merge_strategy.dart
+++ b/lib/models/merge_strategy.dart
@@ -1,0 +1,4 @@
+enum MergeStrategy {
+  appendWithRefinement,
+  replaceOnConflict,
+}

--- a/merge_strategy_notes.md
+++ b/merge_strategy_notes.md
@@ -1,0 +1,15 @@
+# Context Memory Merge Strategies
+
+## appendWithRefinement (default)
+- **Behavior:** new parcels are appended only if they are not redundant with existing ones.
+- **Use case:** gradual context growth while keeping prior summaries intact.
+- **Pros:** preserves history, avoids accidental overwrites.
+- **Cons:** may accumulate near-duplicates if redundancy heuristic fails.
+
+## replaceOnConflict
+- **Behavior:** new parcels replace existing ones when summaries or tags appear to match.
+- **Use case:** prefer most recent or refined summaries when conflicts arise.
+- **Pros:** keeps memory concise and up to date.
+- **Cons:** prior details can be lost if replacements are incorrect.
+
+The default strategy is `appendWithRefinement` to maintain a conservative merge until explicitly overridden.

--- a/test/context_memory_test.dart
+++ b/test/context_memory_test.dart
@@ -1,0 +1,26 @@
+import 'package:test/test.dart';
+import '../lib/models/context_memory.dart';
+import '../lib/models/context_parcel.dart';
+import '../lib/models/merge_strategy.dart';
+
+void main() {
+  group('ContextMemory merge', () {
+    test('appendWithRefinement adds non redundant parcels', () {
+      final a = ContextParcel(summary: 'Init', contributingExchangeIds: [1]);
+      final b = ContextParcel(summary: 'Init', contributingExchangeIds: [2]);
+      final mem1 = ContextMemory(current: a);
+      final mem2 = ContextMemory(current: b);
+      mem1.mergeWith(mem2);
+      expect(mem1.history.isNotEmpty, true);
+    });
+
+    test('replaceOnConflict overwrites matching parcel', () {
+      final a = ContextParcel(summary: 'Init', contributingExchangeIds: [1]);
+      final b = ContextParcel(summary: 'Init refined', contributingExchangeIds: [2]);
+      final mem1 = ContextMemory(current: a);
+      final mem2 = ContextMemory(current: b);
+      mem1.mergeWith(mem2, strategyOverride: MergeStrategy.replaceOnConflict);
+      expect(mem1.current?.summary, 'Init refined');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add merging strategies and redundant parcel checks
- support versioning with snapshots
- expose merge method with strategies
- document merge strategy behavior
- add tests for merge logic

## Testing
- `flutter test` *(fails: command not found)*
- `dart run test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6880235cf1cc83218b235d95f8ab63f3