### PR TITLE
Archive LLM instruction templates task

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -120,3 +120,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507232338][6b805f][DOC][DATA] Added JSON schema examples to ContextParcel, ContextMemory, and ContextDelta models
 [2507222353][158a9d4][FTR][DATA] Implemented merge strategies with versioning
 [2507230004][add7d9][FTR][DOC] Added reusable LLM instruction blocks, merge logic, and prompt templates with examples
+[2507231203][518c97][SNC][DOC] Archived TASKS_specify_llm_instruction_templates.md after Milestone 1 completion

--- a/tasks/archive/TASKS_specify_llm_instruction_templates_DONE.md
+++ b/tasks/archive/TASKS_specify_llm_instruction_templates_DONE.md
@@ -1,3 +1,4 @@
+✅ ARCHIVED — Milestone 1 (LLM Instruction Templates) completed as of 2025-07-23.
 # TASKS_specify_llm_instruction_templates.md
 
 ## 🧠 LLM Instruction Templates (2025-07-22)


### PR DESCRIPTION
## Summary
- move TASKS_specify_llm_instruction_templates.md to tasks/archive
- add archival note
- log archive in CODEXLOG_CURRENT

## Testing
- `./gradlew test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688027f047008321baa470070761968c