### PR TITLE
Add IterativeMergeEngine for LLM-based context merging

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -124,3 +124,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507230125][4c07cf][FTR][UI] Added pinned header to right panel showing expanded exchange metadata and docked scroll behavior
 [2507230150][2979a86][BUG][UI] Fixed exchange toggle to expand or collapse both prompt and response when either section is clicked
 [2507230158][b8214e][REF][UI] Styled collapsed exchanges with reduced background color and padding to reduce visual density and improve focus
+[2507230705][81878e1][FTR][DATA] Implemented IterativeMergeEngine to merge a list of Exchanges into a ContextParcel using LLM loop

--- a/lib/app_config.dart
+++ b/lib/app_config.dart
@@ -1,0 +1,3 @@
+class AppConfig {
+  static bool debugMode = false;
+}

--- a/lib/memory/iterative_merge_engine.dart
+++ b/lib/memory/iterative_merge_engine.dart
@@ -1,0 +1,61 @@
+import '../app_config.dart';
+import '../models/context_parcel.dart';
+import '../models/exchange.dart';
+
+/// Engine that incrementally merges a list of Exchanges into a ContextParcel
+/// using an LLM-backed processor.
+class IterativeMergeEngine {
+  /// Merges [exchanges] sequentially using [SingleExchangeProcessor].
+  /// Returns the final merged [ContextParcel].
+  Future<ContextParcel> mergeAll(List<Exchange> exchanges) async {
+    var context = ContextParcel(summary: '', contributingExchangeIds: []);
+    final mergeHistory = <int>[];
+
+    for (var i = 0; i < exchanges.length; i++) {
+      final ex = exchanges[i];
+      if (ex.prompt.trim().isEmpty &&
+          (ex.response == null || ex.response!.trim().isEmpty)) {
+        print('IterativeMergeEngine: Skipping malformed exchange at index $i');
+        continue;
+      }
+
+      try {
+        context = await SingleExchangeProcessor.process(context, ex);
+        mergeHistory.add(i);
+      } catch (e) {
+        print('IterativeMergeEngine: Warning - failed to merge exchange index $i: $e');
+        continue;
+      }
+
+      if (AppConfig.debugMode) {
+        print('IterativeMergeEngine debug after $i: ${context.toJson()}');
+      }
+    }
+
+    return ContextParcel(
+      summary: context.summary,
+      contributingExchangeIds: mergeHistory,
+      tags: context.tags,
+      assumptions: context.assumptions,
+      confidence: context.confidence,
+    );
+  }
+}
+
+/// Placeholder processor for a single Exchange. In the future this will
+/// interact with an LLM via [LLMClient].
+class SingleExchangeProcessor {
+  static Future<ContextParcel> process(
+      ContextParcel context, Exchange exchange) async {
+    return LLMClient.mergeContext(context, exchange);
+  }
+}
+
+/// Placeholder LLM client.
+class LLMClient {
+  static Future<ContextParcel> mergeContext(
+      ContextParcel context, Exchange exchange) async {
+    // TODO: Replace with real LLM call
+    return context;
+  }
+}

--- a/test/memory/iterative_merge_engine_test.dart
+++ b/test/memory/iterative_merge_engine_test.dart
@@ -1,0 +1,5 @@
+import 'package:test/test.dart';
+
+void main() {
+  // TODO: Add tests for IterativeMergeEngine
+}


### PR DESCRIPTION
## Summary
- implement `IterativeMergeEngine` with placeholder LLM processing
- add `AppConfig` for global debug flag
- create test stub for `IterativeMergeEngine`
- log feature implementation in CODEX log

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688088edf6988321bdbca11e9e31e43c