### PR TITLE
Implement SingleExchangeProcessor merge

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -125,3 +125,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507230150][2979a86][BUG][UI] Fixed exchange toggle to expand or collapse both prompt and response when either section is clicked
 [2507230158][b8214e][REF][UI] Styled collapsed exchanges with reduced background color and padding to reduce visual density and improve focus
 [2507230705][81878e1][FTR][DATA] Implemented IterativeMergeEngine to merge a list of Exchanges into a ContextParcel using LLM loop
+[2507230712][1d688e][FTR][DATA] Implemented SingleExchangeProcessor to merge one Exchange into a ContextParcel using LLM

--- a/lib/memory/iterative_merge_engine.dart
+++ b/lib/memory/iterative_merge_engine.dart
@@ -1,6 +1,7 @@
 import '../app_config.dart';
 import '../models/context_parcel.dart';
 import '../models/exchange.dart';
+import 'single_exchange_processor.dart';
 
 /// Engine that incrementally merges a list of Exchanges into a ContextParcel
 /// using an LLM-backed processor.
@@ -39,23 +40,5 @@ class IterativeMergeEngine {
       assumptions: context.assumptions,
       confidence: context.confidence,
     );
-  }
-}
-
-/// Placeholder processor for a single Exchange. In the future this will
-/// interact with an LLM via [LLMClient].
-class SingleExchangeProcessor {
-  static Future<ContextParcel> process(
-      ContextParcel context, Exchange exchange) async {
-    return LLMClient.mergeContext(context, exchange);
-  }
-}
-
-/// Placeholder LLM client.
-class LLMClient {
-  static Future<ContextParcel> mergeContext(
-      ContextParcel context, Exchange exchange) async {
-    // TODO: Replace with real LLM call
-    return context;
   }
 }

--- a/lib/memory/single_exchange_processor.dart
+++ b/lib/memory/single_exchange_processor.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+
+import '../app_config.dart';
+import '../models/context_parcel.dart';
+import '../models/exchange.dart';
+import '../services/llm_client.dart';
+import '../src/instructions/instruction_templates.dart';
+
+class MergeException implements Exception {
+  final String message;
+  MergeException(this.message);
+  @override
+  String toString() => 'MergeException: $message';
+}
+
+/// Processes a single Exchange using an LLM to merge it with an existing
+/// ContextParcel.
+class SingleExchangeProcessor {
+  /// Sends [exchange] and [inputParcel] to the LLM and returns the merged parcel.
+  static Future<ContextParcel> process(
+      ContextParcel inputParcel, Exchange exchange) async {
+    final promptText = exchange.prompt.trim();
+    final responseText = exchange.response?.trim();
+
+    if (promptText.isEmpty && (responseText == null || responseText.isEmpty)) {
+      print('SingleExchangeProcessor: Warning - malformed exchange');
+      return inputParcel;
+    }
+
+    final prompt = jsonEncode({
+      'context': inputParcel.toJson(),
+      'exchange': {
+        'prompt': exchange.prompt,
+        'response': exchange.response,
+      },
+      'instructions': InstructionTemplates.merge,
+    });
+
+    if (AppConfig.debugMode) {
+      print('SingleExchangeProcessor prompt: $prompt');
+    }
+
+    final raw = await LLMClient.sendPrompt(prompt);
+    if (raw.trim().isEmpty) {
+      throw MergeException('LLM returned empty response');
+    }
+
+    try {
+      final parsed = jsonDecode(raw);
+      final parcel = ContextParcel.fromJson(parsed);
+      if (AppConfig.debugMode) {
+        print('SingleExchangeProcessor returned: ${parcel.toJson()}');
+      }
+      return parcel;
+    } catch (e) {
+      throw MergeException('Failed to parse LLM response: $e');
+    }
+  }
+}

--- a/lib/services/llm_client.dart
+++ b/lib/services/llm_client.dart
@@ -1,0 +1,11 @@
+typedef PromptSender = Future<String> Function(String);
+
+class LLMClient {
+  /// Function used to send prompts. Can be overridden in tests.
+  static PromptSender sendPrompt = _defaultSendPrompt;
+
+  static Future<String> _defaultSendPrompt(String prompt) async {
+    // TODO: Connect to real LLM
+    return '';
+  }
+}

--- a/lib/src/instructions/instruction_templates.dart
+++ b/lib/src/instructions/instruction_templates.dart
@@ -1,0 +1,6 @@
+import 'llm_instruction_templates.dart';
+
+/// Wrapper class exposing commonly used instruction blocks.
+class InstructionTemplates {
+  static const String merge = mergeInstruction;
+}

--- a/test/memory/single_exchange_processor_test.dart
+++ b/test/memory/single_exchange_processor_test.dart
@@ -1,0 +1,55 @@
+import 'package:test/test.dart';
+
+import '../../lib/models/context_parcel.dart';
+import '../../lib/models/exchange.dart';
+import '../../lib/memory/single_exchange_processor.dart';
+import '../../lib/services/llm_client.dart';
+
+void main() {
+  group('SingleExchangeProcessor', () {
+    final originalSender = LLMClient.sendPrompt;
+    tearDown(() => LLMClient.sendPrompt = originalSender);
+
+    test('returns new ContextParcel from LLM', () async {
+      LLMClient.sendPrompt = (prompt) async =>
+          '{"summary":"merged","contributingExchangeIds":[0]}';
+      final input = ContextParcel(summary: '', contributingExchangeIds: []);
+      final ex = Exchange(
+        prompt: 'Hello',
+        promptTimestamp: DateTime.now(),
+        response: 'Hi',
+        responseTimestamp: DateTime.now(),
+      );
+      final result = await SingleExchangeProcessor.process(input, ex);
+      expect(result.summary, 'merged');
+      expect(result.contributingExchangeIds, [0]);
+    });
+
+    test('malformed exchange returns input parcel', () async {
+      final input = ContextParcel(summary: 'keep', contributingExchangeIds: [1]);
+      final ex = Exchange(
+        prompt: '',
+        promptTimestamp: DateTime.now(),
+        response: '',
+        responseTimestamp: DateTime.now(),
+      );
+      final result = await SingleExchangeProcessor.process(input, ex);
+      expect(identical(result, input), isTrue);
+    });
+
+    test('throws MergeException on empty LLM response', () async {
+      LLMClient.sendPrompt = (prompt) async => '';
+      final input = ContextParcel(summary: '', contributingExchangeIds: []);
+      final ex = Exchange(
+        prompt: 'Hi',
+        promptTimestamp: DateTime.now(),
+        response: 'There',
+        responseTimestamp: DateTime.now(),
+      );
+      expect(
+        () => SingleExchangeProcessor.process(input, ex),
+        throwsA(isA<MergeException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- implement SingleExchangeProcessor that calls an LLM
- add stubbed LLMClient and instruction templates
- use new processor in IterativeMergeEngine
- add unit tests for SingleExchangeProcessor
- log new development in CODEXLOG_CURRENT

## Testing
- `dart --version` *(fails: command not found)*
- `dart run test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68808a62f1288321a1a0f58d4ef9866b