### PR TITLE
Implement merge history tracking

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -127,3 +127,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507230705][81878e1][FTR][DATA] Implemented IterativeMergeEngine to merge a list of Exchanges into a ContextParcel using LLM loop
 [2507230712][1d688e][FTR][DATA] Implemented SingleExchangeProcessor to merge one Exchange into a ContextParcel using LLM
 [2507230722][7114fe3][REF][DATA] Connected SingleExchangeProcessor to IterativeMergeEngine and updated context loop handling with debug logging
+[2507230728][2c708d5][FTR][DATA] Added merge history tracking to IterativeMergeEngine for identifying contributing Exchanges

--- a/lib/memory/iterative_merge_engine.dart
+++ b/lib/memory/iterative_merge_engine.dart
@@ -9,7 +9,7 @@ class IterativeMergeEngine {
   /// Merges [exchanges] sequentially using [SingleExchangeProcessor].
   /// Returns the final merged [ContextParcel].
   Future<ContextParcel> mergeAll(List<Exchange> exchanges) async {
-    var context = ContextParcel(summary: '', contributingExchangeIds: []);
+    var context = ContextParcel(summary: '', mergeHistory: []);
     final mergeHistory = <int>[];
     var index = 0;
 
@@ -34,6 +34,10 @@ class IterativeMergeEngine {
         }
         context = result;
         mergeHistory.add(index);
+        if (AppConfig.debugMode) {
+          print('IterativeMergeEngine: merged exchange $index');
+          print('Current merge history: $mergeHistory');
+        }
       } on MergeException catch (e) {
         if (AppConfig.debugMode) {
           print('IterativeMergeEngine: MergeException at index $index: $e');
@@ -51,7 +55,7 @@ class IterativeMergeEngine {
 
     return ContextParcel(
       summary: context.summary,
-      contributingExchangeIds: mergeHistory,
+      mergeHistory: mergeHistory,
       tags: context.tags,
       assumptions: context.assumptions,
       confidence: context.confidence,

--- a/lib/models/context_parcel.dart
+++ b/lib/models/context_parcel.dart
@@ -2,8 +2,8 @@ class ContextParcel {
   /// Human-readable context summary for quick reference
   final String summary;
 
-  /// IDs of exchanges that contributed to this summary
-  final List<int> contributingExchangeIds;
+  /// Indices of exchanges that contributed to this summary
+  final List<int> mergeHistory;
 
   /// Optional manual or inferred tags (e.g. "bug", "feature")
   final List<String> tags;
@@ -16,7 +16,7 @@ class ContextParcel {
 
   ContextParcel({
     required this.summary,
-    required this.contributingExchangeIds,
+      required this.mergeHistory,
     this.tags = const [],
     this.assumptions = const [],
     this.confidence = const {},
@@ -24,7 +24,8 @@ class ContextParcel {
 
   factory ContextParcel.fromJson(Map<String, dynamic> json) => ContextParcel(
         summary: json['summary'],
-        contributingExchangeIds: List<int>.from(json['contributingExchangeIds']),
+        mergeHistory: List<int>.from(
+            json['mergeHistory'] ?? json['contributingExchangeIds'] ?? []),
         tags: List<String>.from(json['tags'] ?? []),
         assumptions: List<String>.from(json['assumptions'] ?? []),
         confidence: Map<String, double>.from(json['confidence'] ?? {}),
@@ -32,7 +33,7 @@ class ContextParcel {
 
   Map<String, dynamic> toJson() => {
         'summary': summary,
-        'contributingExchangeIds': contributingExchangeIds,
+        'mergeHistory': mergeHistory,
         'tags': tags,
         'assumptions': assumptions,
         'confidence': confidence,
@@ -87,7 +88,7 @@ Example:
 
 ContextParcel(
   summary: "Discussed bug in message loader and implemented JSON streaming fix.",
-  contributingExchangeIds: [101, 102, 105],
+  mergeHistory: [101, 102, 105],
   tags: ["bug", "loader", "streaming"],
   assumptions: ["File was too large for previous parser"],
   confidence: {"summary": 0.95}
@@ -99,7 +100,7 @@ ContextParcel(
 
 {
   "summary": "Fixed null pointer in message loader",
-  "contributingExchangeIds": [12, 15, 16],
+  "mergeHistory": [12, 15, 16],
   "tags": ["bug", "loader", "json"],
   "assumptions": ["Data exceeds buffer size"],
   "confidence": {

--- a/test/context_memory_test.dart
+++ b/test/context_memory_test.dart
@@ -6,8 +6,8 @@ import '../lib/models/merge_strategy.dart';
 void main() {
   group('ContextMemory merge', () {
     test('appendWithRefinement adds non redundant parcels', () {
-      final a = ContextParcel(summary: 'Init', contributingExchangeIds: [1]);
-      final b = ContextParcel(summary: 'Init', contributingExchangeIds: [2]);
+      final a = ContextParcel(summary: 'Init', mergeHistory: [1]);
+      final b = ContextParcel(summary: 'Init', mergeHistory: [2]);
       final mem1 = ContextMemory(current: a);
       final mem2 = ContextMemory(current: b);
       mem1.mergeWith(mem2);
@@ -15,8 +15,8 @@ void main() {
     });
 
     test('replaceOnConflict overwrites matching parcel', () {
-      final a = ContextParcel(summary: 'Init', contributingExchangeIds: [1]);
-      final b = ContextParcel(summary: 'Init refined', contributingExchangeIds: [2]);
+      final a = ContextParcel(summary: 'Init', mergeHistory: [1]);
+      final b = ContextParcel(summary: 'Init refined', mergeHistory: [2]);
       final mem1 = ContextMemory(current: a);
       final mem2 = ContextMemory(current: b);
       mem1.mergeWith(mem2, strategyOverride: MergeStrategy.replaceOnConflict);

--- a/test/memory/single_exchange_processor_test.dart
+++ b/test/memory/single_exchange_processor_test.dart
@@ -11,9 +11,9 @@ void main() {
     tearDown(() => LLMClient.sendPrompt = originalSender);
 
     test('returns new ContextParcel from LLM', () async {
-      LLMClient.sendPrompt = (prompt) async =>
-          '{"summary":"merged","contributingExchangeIds":[0]}';
-      final input = ContextParcel(summary: '', contributingExchangeIds: []);
+      LLMClient.sendPrompt =
+          (prompt) async => '{"summary":"merged","mergeHistory":[0]}';
+      final input = ContextParcel(summary: '', mergeHistory: []);
       final ex = Exchange(
         prompt: 'Hello',
         promptTimestamp: DateTime.now(),
@@ -22,11 +22,11 @@ void main() {
       );
       final result = await SingleExchangeProcessor.process(input, ex);
       expect(result.summary, 'merged');
-      expect(result.contributingExchangeIds, [0]);
+      expect(result.mergeHistory, [0]);
     });
 
     test('malformed exchange returns input parcel', () async {
-      final input = ContextParcel(summary: 'keep', contributingExchangeIds: [1]);
+      final input = ContextParcel(summary: 'keep', mergeHistory: [1]);
       final ex = Exchange(
         prompt: '',
         promptTimestamp: DateTime.now(),
@@ -39,7 +39,7 @@ void main() {
 
     test('throws MergeException on empty LLM response', () async {
       LLMClient.sendPrompt = (prompt) async => '';
-      final input = ContextParcel(summary: '', contributingExchangeIds: []);
+      final input = ContextParcel(summary: '', mergeHistory: []);
       final ex = Exchange(
         prompt: 'Hi',
         promptTimestamp: DateTime.now(),


### PR DESCRIPTION
## Summary
- rename `contributingExchangeIds` field to `mergeHistory`
- track merge history indices in `IterativeMergeEngine`
- update unit tests for `ContextParcel` changes
- log new commit in `CODEXLOG_CURRENT.md`

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_b_68808e4d36648321bcf60ecafc71dbaf