### PR TITLE
Implement DebugLogger and iterative merge logging

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -128,3 +128,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507230712][1d688e][FTR][DATA] Implemented SingleExchangeProcessor to merge one Exchange into a ContextParcel using LLM
 [2507230722][7114fe3][REF][DATA] Connected SingleExchangeProcessor to IterativeMergeEngine and updated context loop handling with debug logging
 [2507230728][2c708d5][FTR][DATA] Added merge history tracking to IterativeMergeEngine for identifying contributing Exchanges
+[2507230738][12c457][FTR][DBG] Logged ContextParcel state at each step of merge loop via DebugLogger

--- a/lib/app_config.dart
+++ b/lib/app_config.dart
@@ -1,3 +1,6 @@
 class AppConfig {
   static bool debugMode = false;
+
+  /// Directory where debug logs are written.
+  static String debugOutputDir = 'debug';
 }

--- a/lib/debug/debug_logger.dart
+++ b/lib/debug/debug_logger.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../app_config.dart';
+import '../models/context_parcel.dart';
+
+/// Writes debug logs of [ContextParcel]s during merge operations.
+class DebugLogger {
+  /// Logs [parcel] to a JSON file named `context_step_{stepIndex}.json`
+  /// inside [AppConfig.debugOutputDir]. Includes a timestamp and step index.
+  static void logContextParcel(ContextParcel parcel, int stepIndex) {
+    final ts = DateTime.now().toIso8601String();
+    final outputDir = Directory(AppConfig.debugOutputDir);
+    if (!outputDir.existsSync()) {
+      outputDir.createSync(recursive: true);
+    }
+    final path = '${outputDir.path}/context_step_$stepIndex.json';
+    final data = {
+      'timestamp': ts,
+      'step': stepIndex,
+      'parcel': parcel.toJson(),
+    };
+    File(path).writeAsStringSync(jsonEncode(data));
+    stdout.writeln('DebugLogger: wrote $path at $ts');
+  }
+}

--- a/lib/memory/iterative_merge_engine.dart
+++ b/lib/memory/iterative_merge_engine.dart
@@ -1,6 +1,7 @@
 import '../app_config.dart';
 import '../models/context_parcel.dart';
 import '../models/exchange.dart';
+import '../debug/debug_logger.dart';
 import 'single_exchange_processor.dart';
 
 /// Engine that incrementally merges a list of Exchanges into a ContextParcel
@@ -37,6 +38,7 @@ class IterativeMergeEngine {
         if (AppConfig.debugMode) {
           print('IterativeMergeEngine: merged exchange $index');
           print('Current merge history: $mergeHistory');
+          DebugLogger.logContextParcel(context, index);
         }
       } on MergeException catch (e) {
         if (AppConfig.debugMode) {
@@ -46,10 +48,7 @@ class IterativeMergeEngine {
         continue;
       }
 
-      if (AppConfig.debugMode) {
-        final ts = DateTime.now().toIso8601String();
-        print('[$ts] IterativeMergeEngine after $index: ${context.toJson()}');
-      }
+      // ContextParcel state logged via DebugLogger above when debugMode is true.
       index++;
     }
 

--- a/test/debug/debug_logger_test.dart
+++ b/test/debug/debug_logger_test.dart
@@ -1,0 +1,9 @@
+import 'package:test/test.dart';
+
+void main() {
+  group('DebugLogger', () {
+    test('stub', () {
+      // TODO: implement DebugLogger tests
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `DebugLogger` utility for writing `ContextParcel` states to a debug directory
- expose `debugOutputDir` in `AppConfig`
- log each merge step using `DebugLogger` inside `IterativeMergeEngine`
- create `debug/` folder and test stub for `DebugLogger`
- update CODEX log

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688090e8599c8321b3a91b6084a2855b