### PR TITLE
Add configurable merge strategy

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -129,3 +129,5 @@ This file records all Codex-generated changes and implementations in this projec
 [2507230722][7114fe3][REF][DATA] Connected SingleExchangeProcessor to IterativeMergeEngine and updated context loop handling with debug logging
 [2507230728][2c708d5][FTR][DATA] Added merge history tracking to IterativeMergeEngine for identifying contributing Exchanges
 [2507230738][12c457][FTR][DBG] Logged ContextParcel state at each step of merge loop via DebugLogger
+
+[2507230751][7ea8b5c][FTR][CFG] Added configurable LLM merge strategy injection to IterativeMergeEngine and SingleExchangeProcessor

--- a/lib/app_config.dart
+++ b/lib/app_config.dart
@@ -1,6 +1,9 @@
 class AppConfig {
   static bool debugMode = false;
 
+  /// Merge strategy used by the LLM when processing exchanges.
+  static String mergeStrategy = 'defaultStrategy';
+
   /// Directory where debug logs are written.
   static String debugOutputDir = 'debug';
 }

--- a/lib/models/llm_merge_strategy.dart
+++ b/lib/models/llm_merge_strategy.dart
@@ -1,0 +1,18 @@
+enum MergeStrategy {
+  defaultStrategy,
+  conservative,
+  aggressive,
+}
+
+extension MergeStrategyParser on MergeStrategy {
+  static MergeStrategy fromString(String? value) {
+    switch (value) {
+      case 'conservative':
+        return MergeStrategy.conservative;
+      case 'aggressive':
+        return MergeStrategy.aggressive;
+      default:
+        return MergeStrategy.defaultStrategy;
+    }
+  }
+}

--- a/test/memory/single_exchange_processor_test.dart
+++ b/test/memory/single_exchange_processor_test.dart
@@ -4,6 +4,7 @@ import '../../lib/models/context_parcel.dart';
 import '../../lib/models/exchange.dart';
 import '../../lib/memory/single_exchange_processor.dart';
 import '../../lib/services/llm_client.dart';
+import '../../lib/models/llm_merge_strategy.dart';
 
 void main() {
   group('SingleExchangeProcessor', () {
@@ -20,7 +21,8 @@ void main() {
         response: 'Hi',
         responseTimestamp: DateTime.now(),
       );
-      final result = await SingleExchangeProcessor.process(input, ex);
+      final result = await SingleExchangeProcessor.process(
+          input, ex, MergeStrategy.defaultStrategy);
       expect(result.summary, 'merged');
       expect(result.mergeHistory, [0]);
     });
@@ -33,7 +35,8 @@ void main() {
         response: '',
         responseTimestamp: DateTime.now(),
       );
-      final result = await SingleExchangeProcessor.process(input, ex);
+      final result = await SingleExchangeProcessor.process(
+          input, ex, MergeStrategy.defaultStrategy);
       expect(identical(result, input), isTrue);
     });
 
@@ -47,7 +50,8 @@ void main() {
         responseTimestamp: DateTime.now(),
       );
       expect(
-        () => SingleExchangeProcessor.process(input, ex),
+        () => SingleExchangeProcessor.process(
+            input, ex, MergeStrategy.defaultStrategy),
         throwsA(isA<MergeException>()),
       );
     });


### PR DESCRIPTION
## Summary
- allow choosing MergeStrategy via `IterativeMergeEngine`
- pass MergeStrategy to `SingleExchangeProcessor`
- parse strategy from `AppConfig`
- expose MergeStrategy enum and update tests
- log merge strategy when debugMode is enabled

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68809349403083218ee30301dec0a2ff