### PR TITLE
Add SingleExchangeProcessor tests

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -135,3 +135,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507230806][41871a][FTR][LLM] Added strategy-specific merge instruction templates for SingleExchangeProcessor
 [2507230915][035ad15][FTR][LLM] Completed JSON parsing and return logic for SingleExchangeProcessor LLM response
 [2507230946][b23988][ERR][LLM] Handled malformed or empty Exchange cases in SingleExchangeProcessor
+[2507231008][11c8685][TST][LLM] Added unit tests for SingleExchangeProcessor covering valid, empty, and malformed Exchange cases


### PR DESCRIPTION
## Summary
- add unit tests for SingleExchangeProcessor
- log test run attempt in CODEX log

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6880b3c2c11483219955f291d7cd6823