### PR TITLE
Implement DebugLogger.logLLMCall

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -136,3 +136,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507230915][035ad15][FTR][LLM] Completed JSON parsing and return logic for SingleExchangeProcessor LLM response
 [2507230946][b23988][ERR][LLM] Handled malformed or empty Exchange cases in SingleExchangeProcessor
 [2507231008][11c8685][TST][LLM] Added unit tests for SingleExchangeProcessor covering valid, empty, and malformed Exchange cases
+[2507231014][1d19ea3][FTR][DBG] Added debug logging of LLM calls including instructions, Exchange, and ContextParcel state

--- a/lib/app_config.dart
+++ b/lib/app_config.dart
@@ -1,5 +1,5 @@
 class AppConfig {
-  static bool debugMode = false;
+  static bool debugMode = true; // Toggle as needed
 
   /// Merge strategy used by the LLM when processing exchanges.
   static String mergeStrategy = 'defaultStrategy';

--- a/lib/debug/debug_logger.dart
+++ b/lib/debug/debug_logger.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import '../app_config.dart';
 import '../models/context_parcel.dart';
+import '../models/exchange.dart';
 
 /// Writes debug logs of [ContextParcel]s during merge operations.
 class DebugLogger {
@@ -22,6 +23,29 @@ class DebugLogger {
     };
     File(path).writeAsStringSync(jsonEncode(data));
     stdout.writeln('DebugLogger: wrote $path at $ts');
+  }
+
+  /// Logs each LLM call with instructions, exchange, and context state.
+  static void logLLMCall({
+    required String instructions,
+    required Exchange exchange,
+    required ContextParcel context,
+  }) {
+    final timestamp = DateTime.now().toIso8601String();
+    final log = '''
+    === LLM CALL [$timestamp] ===
+    Instructions:
+    $instructions
+
+    Exchange:
+    PROMPT: ${exchange.prompt}
+    RESPONSE: ${exchange.response}
+
+    ContextParcel:
+    ${jsonEncode(context.toJson())}
+    ''';
+    print(log);
+    // Optionally write to file: debug/llm_call_$timestamp.txt
   }
 
   /// Logs the raw LLM [response] for debugging purposes.

--- a/lib/memory/single_exchange_processor.dart
+++ b/lib/memory/single_exchange_processor.dart
@@ -47,6 +47,11 @@ $responseText''';
 
     if (AppConfig.debugMode) {
       print('SingleExchangeProcessor prompt:\n$prompt');
+      DebugLogger.logLLMCall(
+        instructions: mergeInstructions,
+        exchange: exchange,
+        context: inputParcel,
+      );
     }
 
     final response = await LLMClient.sendPrompt(prompt);

--- a/test/debug/debug_logger_test.dart
+++ b/test/debug/debug_logger_test.dart
@@ -1,9 +1,24 @@
 import 'package:test/test.dart';
 
+import '../../lib/debug/debug_logger.dart';
+import '../../lib/models/context_parcel.dart';
+import '../../lib/models/exchange.dart';
+
 void main() {
   group('DebugLogger', () {
-    test('stub', () {
-      // TODO: implement DebugLogger tests
+    test('stub logLLMCall', () {
+      final ex = Exchange(
+        prompt: 'hi',
+        promptTimestamp: DateTime.now(),
+        response: 'there',
+        responseTimestamp: DateTime.now(),
+      );
+      final ctx = ContextParcel(summary: 's', mergeHistory: const []);
+      DebugLogger.logLLMCall(
+        instructions: 'do it',
+        exchange: ex,
+        context: ctx,
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- add debug mode default in `AppConfig`
- implement `DebugLogger.logLLMCall`
- record each LLM call in `SingleExchangeProcessor`
- create a simple stub test for the logger
- document new entry in CODEX log

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6880b5359a9c8321bd9b08b076932231