### PR TITLE
Implement debug context checkpoints

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -137,3 +137,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507230946][b23988][ERR][LLM] Handled malformed or empty Exchange cases in SingleExchangeProcessor
 [2507231008][11c8685][TST][LLM] Added unit tests for SingleExchangeProcessor covering valid, empty, and malformed Exchange cases
 [2507231014][1d19ea3][FTR][DBG] Added debug logging of LLM calls including instructions, Exchange, and ContextParcel state
+[2507231033][baecf3][FTR][DBG] Added timestamped checkpoint logging of ContextParcel after each merge step

--- a/lib/debug/debug_logger.dart
+++ b/lib/debug/debug_logger.dart
@@ -25,6 +25,24 @@ class DebugLogger {
     stdout.writeln('DebugLogger: wrote $path at $ts');
   }
 
+  /// Writes a timestamped snapshot of [parcel] after each merge step.
+  /// The file is named `context_step_<stepIndex>_<timestamp>.json` inside
+  /// the `debug/` directory. Any errors are caught to avoid disrupting
+  /// the merge process.
+  static void logContextCheckpoint(ContextParcel parcel, int stepIndex) {
+    try {
+      Directory('debug').createSync(recursive: true);
+      final timestamp =
+          DateTime.now().toIso8601String().replaceAll(':', '-');
+      final filename = 'debug/context_step_${stepIndex}_$timestamp.json';
+      final file = File(filename);
+      file.createSync(recursive: true);
+      file.writeAsStringSync(jsonEncode(parcel.toJson()));
+    } catch (_) {
+      // Swallow any exceptions to avoid interfering with merge flow
+    }
+  }
+
   /// Logs each LLM call with instructions, exchange, and context state.
   static void logLLMCall({
     required String instructions,

--- a/lib/memory/iterative_merge_engine.dart
+++ b/lib/memory/iterative_merge_engine.dart
@@ -50,6 +50,7 @@ class IterativeMergeEngine {
           print('IterativeMergeEngine: merged exchange $index');
           print('Current merge history: $mergeHistory');
           DebugLogger.logContextParcel(context, index);
+          DebugLogger.logContextCheckpoint(context, index);
         }
       } on MergeException catch (e) {
         if (AppConfig.debugMode) {


### PR DESCRIPTION
## Summary
- allow DebugLogger to write timestamped checkpoints
- write checkpoints after each merge step
- log commit

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6880b9f5367083219ce177d0264c8f82