### PR TITLE
Implement anomaly logging

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -138,3 +138,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507231008][11c8685][TST][LLM] Added unit tests for SingleExchangeProcessor covering valid, empty, and malformed Exchange cases
 [2507231014][1d19ea3][FTR][DBG] Added debug logging of LLM calls including instructions, Exchange, and ContextParcel state
 [2507231033][baecf3][FTR][DBG] Added timestamped checkpoint logging of ContextParcel after each merge step
+[2507231104][ead3729][FTR][DBG] Added anomaly detection and logging for repeated context, LLM failures, and skipped merges

--- a/lib/debug/debug_logger.dart
+++ b/lib/debug/debug_logger.dart
@@ -76,6 +76,19 @@ class DebugLogger {
     print('[DEBUG WARNING] $message');
   }
 
+  /// Logs an anomaly when [AppConfig.debugMode] is enabled.
+  /// Anomalies represent unexpected states like unchanged context or
+  /// merge failures. Entries are appended to `debug/anomalies.log` with
+  /// an ISO timestamp.
+  static void logAnomaly(String message) {
+    if (!AppConfig.debugMode) return;
+    final timestamp = DateTime.now().toIso8601String();
+    final entry = '[$timestamp] ANOMALY: $message';
+    print(entry);
+    final file = File('debug/anomalies.log');
+    file.writeAsStringSync('$entry\n', mode: FileMode.append);
+  }
+
   /// Logs the parsed [parcel] returned from the LLM.
   static void logParsedParcel(ContextParcel parcel) {
     // TODO: Implement logging of parsed ContextParcel objects


### PR DESCRIPTION
## Summary
- add `logAnomaly` in `DebugLogger` for saving warnings to `debug/anomalies.log`
- warn when context is unchanged after merges
- log when malformed exchanges are skipped
- log LLM failures during merge processing
- update activity log

## Testing
- `dart pub get` *(fails: command not found)*
- `dart run test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6880c0ea2a8c8321a4bddb407a6e8c9a