### PR TITLE
Add ContextDelta diff logging

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -139,3 +139,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507231014][1d19ea3][FTR][DBG] Added debug logging of LLM calls including instructions, Exchange, and ContextParcel state
 [2507231033][baecf3][FTR][DBG] Added timestamped checkpoint logging of ContextParcel after each merge step
 [2507231104][ead3729][FTR][DBG] Added anomaly detection and logging for repeated context, LLM failures, and skipped merges
+[2507231112][8f9a3b1][FTR][DBG] Added optional ContextParcel diff logging via ContextDelta after each merge step

--- a/lib/debug/debug_logger.dart
+++ b/lib/debug/debug_logger.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import '../app_config.dart';
 import '../models/context_parcel.dart';
 import '../models/exchange.dart';
+import '../memory/context_delta.dart';
 
 /// Writes debug logs of [ContextParcel]s during merge operations.
 class DebugLogger {
@@ -38,6 +39,21 @@ class DebugLogger {
       final file = File(filename);
       file.createSync(recursive: true);
       file.writeAsStringSync(jsonEncode(parcel.toJson()));
+    } catch (_) {
+      // Swallow any exceptions to avoid interfering with merge flow
+    }
+  }
+
+  /// Logs the [delta] between ContextParcel states to a timestamped JSON file.
+  static void logContextDelta(ContextDelta delta, int stepIndex) {
+    try {
+      Directory('debug').createSync(recursive: true);
+      final timestamp =
+          DateTime.now().toIso8601String().replaceAll(':', '-');
+      final filename = 'debug/context_delta_${stepIndex}_$timestamp.json';
+      final file = File(filename);
+      file.createSync(recursive: true);
+      file.writeAsStringSync(jsonEncode(delta.toJson()));
     } catch (_) {
       // Swallow any exceptions to avoid interfering with merge flow
     }

--- a/lib/memory/context_delta.dart
+++ b/lib/memory/context_delta.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+
+import '../models/context_parcel.dart';
+
+/// Represents the difference between two [ContextParcel] states.
+class ContextDelta {
+  final Map<String, dynamic> added;
+  final Map<String, dynamic> removed;
+  final Map<String, dynamic> changed;
+
+  ContextDelta({required this.added, required this.removed, required this.changed});
+
+  /// Computes the diff from [oldParcel] to [newParcel].
+  static ContextDelta compute(ContextParcel oldParcel, ContextParcel newParcel) {
+    final oldMap = oldParcel.toJson();
+    final newMap = newParcel.toJson();
+    final added = <String, dynamic>{};
+    final removed = <String, dynamic>{};
+    final changed = <String, dynamic>{};
+
+    for (final key in oldMap.keys) {
+      if (!newMap.containsKey(key)) {
+        removed[key] = oldMap[key];
+      } else if (!_deepEqual(oldMap[key], newMap[key])) {
+        changed[key] = {'from': oldMap[key], 'to': newMap[key]};
+      }
+    }
+    for (final key in newMap.keys) {
+      if (!oldMap.containsKey(key)) {
+        added[key] = newMap[key];
+      }
+    }
+
+    return ContextDelta(added: added, removed: removed, changed: changed);
+  }
+
+  Map<String, dynamic> toJson() => {
+        'added': added,
+        'removed': removed,
+        'changed': changed,
+      };
+
+  static bool _deepEqual(dynamic a, dynamic b) {
+    return jsonEncode(a) == jsonEncode(b);
+  }
+}


### PR DESCRIPTION
## Summary
- compute a diff between ContextParcels using `ContextDelta`
- write delta logs with `DebugLogger.logContextDelta`
- generate delta after each merge step in `IterativeMergeEngine`
- update activity log

## Testing
- `dart format -o none lib/memory/context_delta.dart lib/debug/debug_logger.dart lib/memory/iterative_merge_engine.dart`
- `dart analyze` *(fails: package resolution errors and Flutter SDK missing)*

------
https://chatgpt.com/codex/tasks/task_b_6880c2b5c3cc8321a291634073975082