### PR TITLE
Add debug config toggle

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -1,5 +1,8 @@
 class AppConfig {
-  static bool debugMode = true; // Toggle as needed
+  static bool debugMode = false;
+
+  static void enableDebug() => debugMode = true;
+  static void disableDebug() => debugMode = false;
 
   /// Merge strategy used by the LLM when processing exchanges.
   static String mergeStrategy = 'defaultStrategy';

--- a/lib/debug/debug_logger.dart
+++ b/lib/debug/debug_logger.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
-import '../app_config.dart';
+import '../config/app_config.dart';
 import '../models/context_parcel.dart';
 import '../models/exchange.dart';
 import '../memory/context_delta.dart';
@@ -11,6 +11,7 @@ class DebugLogger {
   /// Logs [parcel] to a JSON file named `context_step_{stepIndex}.json`
   /// inside [AppConfig.debugOutputDir]. Includes a timestamp and step index.
   static void logContextParcel(ContextParcel parcel, int stepIndex) {
+    if (!AppConfig.debugMode) return;
     final ts = DateTime.now().toIso8601String();
     final outputDir = Directory(AppConfig.debugOutputDir);
     if (!outputDir.existsSync()) {
@@ -31,6 +32,7 @@ class DebugLogger {
   /// the `debug/` directory. Any errors are caught to avoid disrupting
   /// the merge process.
   static void logContextCheckpoint(ContextParcel parcel, int stepIndex) {
+    if (!AppConfig.debugMode) return;
     try {
       Directory('debug').createSync(recursive: true);
       final timestamp =
@@ -46,6 +48,7 @@ class DebugLogger {
 
   /// Logs the [delta] between ContextParcel states to a timestamped JSON file.
   static void logContextDelta(ContextDelta delta, int stepIndex) {
+    if (!AppConfig.debugMode) return;
     try {
       Directory('debug').createSync(recursive: true);
       final timestamp =
@@ -65,6 +68,7 @@ class DebugLogger {
     required Exchange exchange,
     required ContextParcel context,
   }) {
+    if (!AppConfig.debugMode) return;
     final timestamp = DateTime.now().toIso8601String();
     final log = '''
     === LLM CALL [$timestamp] ===
@@ -84,11 +88,13 @@ class DebugLogger {
 
   /// Logs the raw LLM [response] for debugging purposes.
   static void logRawResponse(String response) {
+    if (!AppConfig.debugMode) return;
     // TODO: Implement logging of raw LLM responses
   }
 
   /// Logs a warning message when [AppConfig.debugMode] is enabled.
   static void logWarning(String message) {
+    if (!AppConfig.debugMode) return;
     print('[DEBUG WARNING] $message');
   }
 
@@ -107,6 +113,7 @@ class DebugLogger {
 
   /// Logs the parsed [parcel] returned from the LLM.
   static void logParsedParcel(ContextParcel parcel) {
+    if (!AppConfig.debugMode) return;
     // TODO: Implement logging of parsed ContextParcel objects
   }
 }

--- a/lib/memory/iterative_merge_engine.dart
+++ b/lib/memory/iterative_merge_engine.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import '../app_config.dart';
+import '../config/app_config.dart';
 import '../models/context_parcel.dart';
 import '../models/exchange.dart';
 import '../debug/debug_logger.dart';

--- a/lib/memory/single_exchange_processor.dart
+++ b/lib/memory/single_exchange_processor.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import '../app_config.dart';
+import '../config/app_config.dart';
 import '../models/context_parcel.dart';
 import '../models/exchange.dart';
 import '../models/llm_merge_strategy.dart';

--- a/test/config/app_config_test.dart
+++ b/test/config/app_config_test.dart
@@ -1,0 +1,13 @@
+import 'package:test/test.dart';
+import '../../lib/config/app_config.dart';
+
+void main() {
+  group('AppConfig', () {
+    test('toggle debug mode', () {
+      AppConfig.disableDebug();
+      expect(AppConfig.debugMode, isFalse);
+      AppConfig.enableDebug();
+      expect(AppConfig.debugMode, isTrue);
+    });
+  });
+}

--- a/test/memory/single_exchange_processor_test.dart
+++ b/test/memory/single_exchange_processor_test.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'package:test/test.dart';
 
-import '../../lib/app_config.dart';
+import '../../lib/config/app_config.dart';
 import '../../lib/models/context_parcel.dart';
 import '../../lib/models/exchange.dart';
 import '../../lib/memory/single_exchange_processor.dart';


### PR DESCRIPTION
## Summary
- move `AppConfig` to `lib/config` and add enable/disable helpers
- guard debug logging helpers with `AppConfig.debugMode`
- update imports after config relocation
- add tests covering the new toggle logic

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_6880c4b76b2c832186b40fe10630387c