### PR TITLE
Add ContextMemoryBuilder

### DIFF
--- a/lib/services/context_memory_builder.dart
+++ b/lib/services/context_memory_builder.dart
@@ -1,0 +1,41 @@
+import '../models/context_memory.dart';
+import '../models/context_parcel.dart';
+
+/// Utility for constructing a finalized [ContextMemory] from the
+/// latest [ContextParcel] produced by the merge pipeline.
+class ContextMemoryBuilder {
+  /// Combines [latest] with optional [history] into a new [ContextMemory].
+  /// If [generatedAt] is not provided, the current time is used.
+  /// If [totalExchangeCount] is null, it is inferred from the highest
+  /// exchange index present in the parcel merge histories.
+  static ContextMemory buildFinalMemory({
+    required ContextParcel latest,
+    List<ContextParcel> history = const [],
+    String? sourceConversationId,
+    DateTime? generatedAt,
+    int? totalExchangeCount,
+    String? mergeStrategy,
+    String? notes,
+  }) {
+    final parcels = <ContextParcel>[...history, latest];
+
+    final genAt = generatedAt ?? DateTime.now();
+    int? exchangeCount = totalExchangeCount;
+    if (exchangeCount == null) {
+      final ids = parcels.expand((p) => p.mergeHistory).toList();
+      if (ids.isNotEmpty) {
+        final maxId = ids.reduce((a, b) => a > b ? a : b);
+        exchangeCount = maxId + 1;
+      }
+    }
+
+    return ContextMemory(
+      parcels: parcels,
+      generatedAt: genAt,
+      conversationId: sourceConversationId,
+      exchangeCount: exchangeCount,
+      strategy: mergeStrategy,
+      notes: notes,
+    );
+  }
+}

--- a/test/memory/context_memory_builder_test.dart
+++ b/test/memory/context_memory_builder_test.dart
@@ -1,0 +1,39 @@
+import 'package:test/test.dart';
+
+import '../../lib/models/context_parcel.dart';
+import '../../lib/services/context_memory_builder.dart';
+
+void main() {
+  group('ContextMemoryBuilder', () {
+    test('builds memory with history and metadata', () {
+      final latest = ContextParcel(summary: 'final', mergeHistory: [0, 1]);
+      final prev = ContextParcel(summary: 'prev', mergeHistory: [0]);
+      final ts = DateTime.parse('2025-07-24T00:00:00Z');
+      final memory = ContextMemoryBuilder.buildFinalMemory(
+        latest: latest,
+        history: [prev],
+        sourceConversationId: 'c1',
+        generatedAt: ts,
+        totalExchangeCount: 2,
+        mergeStrategy: 'default',
+        notes: 'n',
+      );
+      expect(memory.parcels.length, 2);
+      expect(memory.parcels.first.summary, 'prev');
+      expect(memory.parcels.last.summary, 'final');
+      expect(memory.conversationId, 'c1');
+      expect(memory.exchangeCount, 2);
+      expect(memory.strategy, 'default');
+      expect(memory.notes, 'n');
+      expect(memory.generatedAt, ts);
+    });
+
+    test('infers generatedAt and exchangeCount', () {
+      final latest = ContextParcel(summary: 'end', mergeHistory: [0, 1, 2]);
+      final memory = ContextMemoryBuilder.buildFinalMemory(latest: latest);
+      expect(memory.parcels.length, 1);
+      expect(memory.generatedAt, isNotNull);
+      expect(memory.exchangeCount, 3);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `ContextMemoryBuilder` with `buildFinalMemory`
- cover builder logic with unit tests

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688168331a0483218274d86e3c0ab6ca