### PR TITLE
Add optional metadata fields to ContextMemory

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -142,3 +142,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507231112][8f9a3b1][FTR][DBG] Added optional ContextParcel diff logging via ContextDelta after each merge step
 [2507231126][13e17e1][SNC][DOC] Archived all Milestone 2 task files and finalized missing Milestone 1 task file moves
 [2507232300][40a97f][FTR][DATA] Defined final ContextMemory structure with metadata
+[2507232324][d76868c][FTR][DATA] Added optional metadata fields in ContextMemory

--- a/lib/models/context_memory.dart
+++ b/lib/models/context_memory.dart
@@ -10,13 +10,13 @@ class ContextMemory {
   /// Ordered list of merged context parcels representing the conversation.
   final List<ContextParcel> parcels;
 
-  /// Time the memory was generated, if known.
+  /// Timestamp when this memory snapshot was generated.
   final DateTime? generatedAt;
 
-  /// Identifier for the source conversation.
-  final String? conversationId;
+  /// Identifier for the original conversation this memory summarizes.
+  final String? sourceConversationId;
 
-  /// Total number of Exchanges that were processed.
+  /// Total number of exchanges that contributed to this memory.
   final int? exchangeCount;
 
   /// Merge strategy or version string used during generation.
@@ -28,7 +28,7 @@ class ContextMemory {
   ContextMemory({
     List<ContextParcel>? parcels,
     this.generatedAt,
-    this.conversationId,
+    this.sourceConversationId,
     this.exchangeCount,
     this.strategy,
     this.notes,
@@ -42,7 +42,7 @@ class ContextMemory {
         generatedAt: json['generatedAt'] != null
             ? DateTime.parse(json['generatedAt'])
             : null,
-        conversationId: json['conversationId'] as String?,
+        sourceConversationId: json['sourceConversationId'] as String?,
         exchangeCount: json['exchangeCount'] as int?,
         strategy: json['strategy'] as String?,
         notes: json['notes'] as String?,
@@ -51,7 +51,7 @@ class ContextMemory {
   Map<String, dynamic> toJson() => {
         'parcels': parcels.map((e) => e.toJson()).toList(),
         'generatedAt': generatedAt?.toIso8601String(),
-        'conversationId': conversationId,
+        'sourceConversationId': sourceConversationId,
         'exchangeCount': exchangeCount,
         'strategy': strategy,
         'notes': notes,

--- a/lib/services/context_memory_builder.dart
+++ b/lib/services/context_memory_builder.dart
@@ -32,7 +32,7 @@ class ContextMemoryBuilder {
     return ContextMemory(
       parcels: parcels,
       generatedAt: genAt,
-      conversationId: sourceConversationId,
+      sourceConversationId: sourceConversationId,
       exchangeCount: exchangeCount,
       strategy: mergeStrategy,
       notes: notes,

--- a/test/context_memory_test.dart
+++ b/test/context_memory_test.dart
@@ -11,7 +11,7 @@ void main() {
           ContextParcel(summary: 'b', mergeHistory: [2]),
         ],
         generatedAt: DateTime.parse('2025-07-23T00:00:00Z'),
-        conversationId: 'conv1',
+        sourceConversationId: 'conv1',
         exchangeCount: 2,
         strategy: 'test',
         notes: 'n',
@@ -19,7 +19,7 @@ void main() {
       final json = memory.toJson();
       final roundTrip = ContextMemory.fromJson(json);
       expect(roundTrip.parcels.length, 2);
-      expect(roundTrip.conversationId, 'conv1');
+      expect(roundTrip.sourceConversationId, 'conv1');
       expect(roundTrip.exchangeCount, 2);
       expect(roundTrip.strategy, 'test');
       expect(roundTrip.notes, 'n');

--- a/test/memory/context_memory_builder_test.dart
+++ b/test/memory/context_memory_builder_test.dart
@@ -21,7 +21,7 @@ void main() {
       expect(memory.parcels.length, 2);
       expect(memory.parcels.first.summary, 'prev');
       expect(memory.parcels.last.summary, 'final');
-      expect(memory.conversationId, 'c1');
+      expect(memory.sourceConversationId, 'c1');
       expect(memory.exchangeCount, 2);
       expect(memory.strategy, 'default');
       expect(memory.notes, 'n');


### PR DESCRIPTION
## Summary
- rename `conversationId` to `sourceConversationId`
- populate new field via `ContextMemoryBuilder`
- adjust serialization tests
- log change

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68816e92e4048321b48a3840bf1c9759