### PR TITLE
Add LLM annotation fields to ContextMemory

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -143,3 +143,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507231126][13e17e1][SNC][DOC] Archived all Milestone 2 task files and finalized missing Milestone 1 task file moves
 [2507232300][40a97f][FTR][DATA] Defined final ContextMemory structure with metadata
 [2507232324][d76868c][FTR][DATA] Added optional metadata fields in ContextMemory
+[2507232352][36624e9][FTR][DATA] Added confidence, completeness, limitations fields

--- a/lib/models/context_memory.dart
+++ b/lib/models/context_memory.dart
@@ -22,8 +22,26 @@ class ContextMemory {
   /// Merge strategy or version string used during generation.
   final String? strategy;
 
-  /// Optional notes such as LLM confidence or limitations.
+  /// Optional free-form notes about this memory snapshot.
+  ///
+  /// This may include explanations from the LLM, caveats, or other
+  /// context that doesn't fit in the dedicated fields below.
   final String? notes;
+
+  /// Overall confidence score or description provided by the LLM.
+  ///
+  /// Use this to gauge how reliable the summarized context may be.
+  final String? confidence;
+
+  /// Indicates how complete the LLM believes this memory to be.
+  ///
+  /// Useful when only a partial conversation was available during
+  /// summarization.
+  final String? completeness;
+
+  /// Any known limitations or blind spots noted by the LLM when
+  /// generating this memory.
+  final String? limitations;
 
   ContextMemory({
     List<ContextParcel>? parcels,
@@ -32,6 +50,9 @@ class ContextMemory {
     this.exchangeCount,
     this.strategy,
     this.notes,
+    this.confidence,
+    this.completeness,
+    this.limitations,
   }) : parcels = parcels ?? [];
 
   factory ContextMemory.fromJson(Map<String, dynamic> json) => ContextMemory(
@@ -46,6 +67,9 @@ class ContextMemory {
         exchangeCount: json['exchangeCount'] as int?,
         strategy: json['strategy'] as String?,
         notes: json['notes'] as String?,
+        confidence: json['confidence'] as String?,
+        completeness: json['completeness'] as String?,
+        limitations: json['limitations'] as String?,
       );
 
   Map<String, dynamic> toJson() => {
@@ -55,5 +79,8 @@ class ContextMemory {
         'exchangeCount': exchangeCount,
         'strategy': strategy,
         'notes': notes,
+        'confidence': confidence,
+        'completeness': completeness,
+        'limitations': limitations,
       };
 }

--- a/lib/services/context_memory_builder.dart
+++ b/lib/services/context_memory_builder.dart
@@ -16,6 +16,12 @@ class ContextMemoryBuilder {
     int? totalExchangeCount,
     String? mergeStrategy,
     String? notes,
+    /// Overall confidence annotation from the LLM, if provided.
+    String? confidence,
+    /// How complete the LLM believes this memory is.
+    String? completeness,
+    /// Any limitations or caveats noted when generating the memory.
+    String? limitations,
   }) {
     final parcels = <ContextParcel>[...history, latest];
 
@@ -36,6 +42,9 @@ class ContextMemoryBuilder {
       exchangeCount: exchangeCount,
       strategy: mergeStrategy,
       notes: notes,
+      confidence: confidence,
+      completeness: completeness,
+      limitations: limitations,
     );
   }
 }

--- a/test/context_memory_test.dart
+++ b/test/context_memory_test.dart
@@ -15,6 +15,9 @@ void main() {
         exchangeCount: 2,
         strategy: 'test',
         notes: 'n',
+        confidence: '0.8',
+        completeness: 'partial',
+        limitations: 'some missing data',
       );
       final json = memory.toJson();
       final roundTrip = ContextMemory.fromJson(json);
@@ -23,6 +26,9 @@ void main() {
       expect(roundTrip.exchangeCount, 2);
       expect(roundTrip.strategy, 'test');
       expect(roundTrip.notes, 'n');
+      expect(roundTrip.confidence, '0.8');
+      expect(roundTrip.completeness, 'partial');
+      expect(roundTrip.limitations, 'some missing data');
       expect(roundTrip.generatedAt, DateTime.parse('2025-07-23T00:00:00Z'));
     });
   });

--- a/test/memory/context_memory_builder_test.dart
+++ b/test/memory/context_memory_builder_test.dart
@@ -17,6 +17,9 @@ void main() {
         totalExchangeCount: 2,
         mergeStrategy: 'default',
         notes: 'n',
+        confidence: '0.9',
+        completeness: 'complete',
+        limitations: 'none',
       );
       expect(memory.parcels.length, 2);
       expect(memory.parcels.first.summary, 'prev');
@@ -25,6 +28,9 @@ void main() {
       expect(memory.exchangeCount, 2);
       expect(memory.strategy, 'default');
       expect(memory.notes, 'n');
+      expect(memory.confidence, '0.9');
+      expect(memory.completeness, 'complete');
+      expect(memory.limitations, 'none');
       expect(memory.generatedAt, ts);
     });
 


### PR DESCRIPTION
## Summary
- allow `ContextMemory` to store `confidence`, `completeness`, and `limitations`
- pass these annotations through `ContextMemoryBuilder`
- update unit tests for the new fields
- log change

## Testing
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_688174f1e66883218e8f107c0527dabe