### PR TITLE
Define export formats enum

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -144,3 +144,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507232300][40a97f][FTR][DATA] Defined final ContextMemory structure with metadata
 [2507232324][d76868c][FTR][DATA] Added optional metadata fields in ContextMemory
 [2507232352][36624e9][FTR][DATA] Added confidence, completeness, limitations fields
+[2507240010][87e711][FTR][DATA] Defined export formats enumeration and metadata

--- a/lib/export/export_formats.dart
+++ b/lib/export/export_formats.dart
@@ -1,0 +1,62 @@
+/// Supported export output formats for ContextMemory views.
+///
+/// These formats allow the conversation context to be re-used
+/// in documentation, summaries, or downstream tooling.
+/// Each enum value includes documentation on its intended use,
+/// target audience, and output characteristics.
+
+enum ExportFormat {
+  /// High-fidelity conversation resume in Markdown.
+  ///
+  /// * **Intended use:** recreate the original conversation
+  ///   with minimal loss of detail when resuming work.
+  /// * **Target audience:** developers and reviewers who
+  ///   need the full dialogue for reference.
+  /// * **Output characteristics:** formatted Markdown with
+  ///   headings, timestamps, and verbatim prompts/responses.
+  markdownResume,
+
+  /// Concise design or feature summary in plain text.
+  ///
+  /// * **Intended use:** capture key decisions or features
+  ///   discussed during the conversation.
+  /// * **Target audience:** project managers or team members
+  ///   seeking a quick overview without full transcripts.
+  /// * **Output characteristics:** paragraph style text
+  ///   summarizing main ideas and follow-up actions.
+  featureSummary,
+
+  /// Machine-readable JSON representation.
+  ///
+  /// * **Intended use:** feed context into automated tools
+  ///   or later processing stages.
+  /// * **Target audience:** scripts and services that parse
+  ///   structured conversation memory.
+  /// * **Output characteristics:** well-formed JSON matching
+  ///   the `ContextMemory` schema.
+  structuredJson,
+}
+
+/// Metadata describing additional details for each [ExportFormat].
+class ExportFormatInfo {
+  /// Default file extension, without leading dot.
+  final String extension;
+
+  /// Suggested filename suffix appended to a base name.
+  final String suffix;
+
+  /// One-line description of the format purpose.
+  final String description;
+
+  const ExportFormatInfo(this.extension, this.suffix, this.description);
+}
+
+/// Lookup table of export format metadata.
+const Map<ExportFormat, ExportFormatInfo> exportFormatInfo = {
+  ExportFormat.markdownResume:
+      ExportFormatInfo('md', 'resume', 'Markdown conversation resume block'),
+  ExportFormat.featureSummary:
+      ExportFormatInfo('txt', 'summary', 'Human-readable feature summary'),
+  ExportFormat.structuredJson:
+      ExportFormatInfo('json', 'memory', 'Structured JSON memory output'),
+};


### PR DESCRIPTION
## Summary
- add export formats to drive context exports
- include companion metadata for file extension, suffix, and description

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68817940ca208321b785f49731f9d2a2