### PR TITLE
Implement ContextMemory exporters

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -145,3 +145,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507232324][d76868c][FTR][DATA] Added optional metadata fields in ContextMemory
 [2507232352][36624e9][FTR][DATA] Added confidence, completeness, limitations fields
 [2507240010][87e711][FTR][DATA] Defined export formats enumeration and metadata
+[2507240022][191d26c][FTR][DATA] Added pluggable ContextMemory exporters

--- a/lib/export/context_memory_exporter.dart
+++ b/lib/export/context_memory_exporter.dart
@@ -1,0 +1,13 @@
+import '../models/context_memory.dart';
+import 'export_formats.dart';
+
+/// Base class for modules that convert a [ContextMemory] into
+/// a specific output format.
+abstract class ContextMemoryExporter {
+  /// The [ExportFormat] supported by this exporter.
+  ExportFormat get format;
+
+  /// Returns a string representation of [memory] in the
+  /// desired output format.
+  String export(ContextMemory memory);
+}

--- a/lib/export/exporter_registry.dart
+++ b/lib/export/exporter_registry.dart
@@ -1,0 +1,24 @@
+import 'context_memory_exporter.dart';
+import 'export_formats.dart';
+import 'markdown_resume_exporter.dart';
+import 'feature_summary_exporter.dart';
+import 'structured_json_exporter.dart';
+
+/// Provides lookup of [ContextMemoryExporter] implementations by [ExportFormat].
+class ExporterRegistry {
+  static final Map<ExportFormat, ContextMemoryExporter> _exporters = {
+    ExportFormat.markdownResume: MarkdownResumeExporter(),
+    ExportFormat.featureSummary: FeatureSummaryExporter(),
+    ExportFormat.structuredJson: StructuredJsonExporter(),
+  };
+
+  /// Returns the exporter registered for [format], or null if none exists.
+  static ContextMemoryExporter? getExporter(ExportFormat format) {
+    return _exporters[format];
+  }
+
+  /// Registers a custom [exporter], overriding any existing one for its format.
+  static void registerExporter(ContextMemoryExporter exporter) {
+    _exporters[exporter.format] = exporter;
+  }
+}

--- a/lib/export/feature_summary_exporter.dart
+++ b/lib/export/feature_summary_exporter.dart
@@ -1,0 +1,14 @@
+import '../models/context_memory.dart';
+import 'context_memory_exporter.dart';
+import 'export_formats.dart';
+
+/// Exports a concise feature summary of [ContextMemory].
+class FeatureSummaryExporter implements ContextMemoryExporter {
+  @override
+  ExportFormat get format => ExportFormat.featureSummary;
+
+  @override
+  String export(ContextMemory memory) {
+    return memory.parcels.map((p) => p.summary).join('\n');
+  }
+}

--- a/lib/export/markdown_resume_exporter.dart
+++ b/lib/export/markdown_resume_exporter.dart
@@ -1,0 +1,25 @@
+import '../models/context_memory.dart';
+import '../models/context_parcel.dart';
+import 'context_memory_exporter.dart';
+import 'export_formats.dart';
+
+/// Exports [ContextMemory] as a Markdown conversation resume block.
+class MarkdownResumeExporter implements ContextMemoryExporter {
+  @override
+  ExportFormat get format => ExportFormat.markdownResume;
+
+  @override
+  String export(ContextMemory memory) {
+    final buffer = StringBuffer();
+    for (int i = 0; i < memory.parcels.length; i++) {
+      final ContextParcel parcel = memory.parcels[i];
+      buffer.writeln('### Step ${i + 1}');
+      buffer.writeln(parcel.summary);
+      if (parcel.tags.isNotEmpty) {
+        buffer.writeln('_Tags:_ ${parcel.tags.join(', ')}');
+      }
+      buffer.writeln();
+    }
+    return buffer.toString().trim();
+  }
+}

--- a/lib/export/structured_json_exporter.dart
+++ b/lib/export/structured_json_exporter.dart
@@ -1,0 +1,16 @@
+import 'dart:convert';
+
+import '../models/context_memory.dart';
+import 'context_memory_exporter.dart';
+import 'export_formats.dart';
+
+/// Exports [ContextMemory] as structured JSON.
+class StructuredJsonExporter implements ContextMemoryExporter {
+  @override
+  ExportFormat get format => ExportFormat.structuredJson;
+
+  @override
+  String export(ContextMemory memory) {
+    return jsonEncode(memory.toJson());
+  }
+}


### PR DESCRIPTION
## Summary
- add pluggable `ContextMemoryExporter` base class
- implement Markdown, feature-summary, and JSON exporters
- provide an `ExporterRegistry` for lookup
- log exporter creation in `CODEXLOG_CURRENT`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68817c09929c8321b735fde0879053d4