### PR TITLE
Add metadata blocks to export views

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -146,3 +146,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507232352][36624e9][FTR][DATA] Added confidence, completeness, limitations fields
 [2507240010][87e711][FTR][DATA] Defined export formats enumeration and metadata
 [2507240022][191d26c][FTR][DATA] Added pluggable ContextMemory exporters
+[2507240032][cfddc8f][FTR][DATA] Added metadata blocks to all ContextMemory export views

--- a/lib/export/feature_summary_exporter.dart
+++ b/lib/export/feature_summary_exporter.dart
@@ -9,6 +9,20 @@ class FeatureSummaryExporter implements ContextMemoryExporter {
 
   @override
   String export(ContextMemory memory) {
-    return memory.parcels.map((p) => p.summary).join('\n');
+    final info = exportFormatInfo[format];
+    final buffer = StringBuffer();
+
+    buffer.writeln('Export Metadata:');
+    buffer.writeln('- Format: Feature Summary');
+    final ts = (memory.generatedAt ?? DateTime.now()).toIso8601String();
+    buffer.writeln('- Generated: $ts');
+    if (memory.sourceConversationId != null) {
+      buffer.writeln('- Source Conversation: ${memory.sourceConversationId}');
+    }
+    buffer.writeln('- Purpose: ${info?.description}');
+    buffer.writeln();
+
+    buffer.writeAll(memory.parcels.map((p) => p.summary), '\n');
+    return buffer.toString().trim();
   }
 }

--- a/lib/export/markdown_resume_exporter.dart
+++ b/lib/export/markdown_resume_exporter.dart
@@ -11,6 +11,17 @@ class MarkdownResumeExporter implements ContextMemoryExporter {
   @override
   String export(ContextMemory memory) {
     final buffer = StringBuffer();
+    final info = exportFormatInfo[format];
+
+    buffer.writeln('#### Export Metadata');
+    buffer.writeln('- Format: Markdown Resume');
+    final ts = (memory.generatedAt ?? DateTime.now()).toIso8601String();
+    buffer.writeln('- Generated: $ts');
+    if (memory.sourceConversationId != null) {
+      buffer.writeln('- Source Conversation: ${memory.sourceConversationId}');
+    }
+    buffer.writeln('- Purpose: ${info?.description}');
+    buffer.writeln();
     for (int i = 0; i < memory.parcels.length; i++) {
       final ContextParcel parcel = memory.parcels[i];
       buffer.writeln('### Step ${i + 1}');

--- a/lib/export/structured_json_exporter.dart
+++ b/lib/export/structured_json_exporter.dart
@@ -11,6 +11,14 @@ class StructuredJsonExporter implements ContextMemoryExporter {
 
   @override
   String export(ContextMemory memory) {
-    return jsonEncode(memory.toJson());
+    final info = exportFormatInfo[format];
+    final data = Map<String, dynamic>.from(memory.toJson());
+    data['_meta'] = {
+      'format': 'structuredJson',
+      'generatedAt': (memory.generatedAt ?? DateTime.now()).toIso8601String(),
+      'sourceConversationId': memory.sourceConversationId,
+      'description': info?.description,
+    };
+    return jsonEncode(data);
   }
 }


### PR DESCRIPTION
## Summary
- add export metadata for markdown resume view
- include metadata in feature summary view
- inject meta section into structured JSON output
- update log

## Testing
- `dart format lib/export/markdown_resume_exporter.dart lib/export/feature_summary_exporter.dart lib/export/structured_json_exporter.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68817e8684fc8321a228d2a05aab328a