### PR TITLE
Implement ContextMemoryRouter

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -147,3 +147,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507240010][87e711][FTR][DATA] Defined export formats enumeration and metadata
 [2507240022][191d26c][FTR][DATA] Added pluggable ContextMemory exporters
 [2507240032][cfddc8f][FTR][DATA] Added metadata blocks to all ContextMemory export views
+[2507240201][f46066][FTR][DATA] Added ContextMemoryRouter for routing memory exports

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -9,4 +9,7 @@ class AppConfig {
 
   /// Directory where debug logs are written.
   static String debugOutputDir = 'debug';
+
+  /// Directory where exported ContextMemory files are written.
+  static String memoryOutputDir = 'context_memory';
 }

--- a/lib/routing/context_memory_router.dart
+++ b/lib/routing/context_memory_router.dart
@@ -1,0 +1,78 @@
+import 'dart:io';
+
+import '../config/app_config.dart';
+import '../models/context_memory.dart';
+import '../export/context_memory_exporter.dart';
+import '../export/export_formats.dart';
+import '../export/exporter_registry.dart';
+
+/// Possible destinations for exported [ContextMemory].
+enum OutputDestination {
+  /// Save exported data to local files.
+  fileSystem,
+
+  /// Placeholder for a log summary viewer.
+  logViewer,
+
+  /// Placeholder for documentation generation pipeline.
+  documentationGenerator,
+
+  /// Placeholder for error or fix pattern archive routing.
+  errorArchive,
+}
+
+/// Routes [ContextMemory] exports to configured destinations.
+class ContextMemoryRouter {
+  final List<OutputDestination> destinations;
+
+  /// Creates a router that writes to [destinations]. If none are provided,
+  /// [OutputDestination.fileSystem] is used by default.
+  ContextMemoryRouter({List<OutputDestination>? destinations})
+      : destinations = destinations ?? [OutputDestination.fileSystem];
+
+  /// Exports [memory] using each of the requested [formats] and dispatches the
+  /// results to all configured destinations.
+  Future<void> route(ContextMemory memory, List<ExportFormat> formats) async {
+    for (final format in formats) {
+      final ContextMemoryExporter? exporter =
+          ExporterRegistry.getExporter(format);
+      if (exporter == null) continue;
+      final output = exporter.export(memory);
+      for (final dest in destinations) {
+        switch (dest) {
+          case OutputDestination.fileSystem:
+            await _writeToFileSystem(output, memory, format);
+            break;
+          case OutputDestination.logViewer:
+            // TODO: integrate with log summary viewer
+            break;
+          case OutputDestination.documentationGenerator:
+            // TODO: integrate with documentation generator
+            break;
+          case OutputDestination.errorArchive:
+            // TODO: integrate with error/fix archive
+            break;
+        }
+      }
+    }
+  }
+
+  Future<void> _writeToFileSystem(
+      String content, ContextMemory memory, ExportFormat format) async {
+    final info = exportFormatInfo[format];
+    final dir = Directory(AppConfig.memoryOutputDir);
+    if (!dir.existsSync()) {
+      dir.createSync(recursive: true);
+    }
+    final ts = (memory.generatedAt ?? DateTime.now())
+        .toIso8601String()
+        .replaceAll(':', '-');
+    final base = (memory.sourceConversationId ?? 'memory')
+        .replaceAll(RegExp(r'[\\/\:]'), '_');
+    final filename =
+        '${base}_${info?.suffix ?? format.name}_${ts}.${info?.extension ?? 'txt'}';
+    final file = File('${dir.path}/$filename');
+    await file.writeAsString(content);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `ContextMemoryRouter` to dispatch `ContextMemory` exports
- support filesystem destination and placeholders for future routing
- store output directory in `AppConfig`
- log new feature

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68819335a26083219e5921a398c7dc87