### PR TITLE
Extend ContextMemory routing

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -148,3 +148,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507240022][191d26c][FTR][DATA] Added pluggable ContextMemory exporters
 [2507240032][cfddc8f][FTR][DATA] Added metadata blocks to all ContextMemory export views
 [2507240201][f46066][FTR][DATA] Added ContextMemoryRouter for routing memory exports
+[2507240217][84726d][FTR][DATA] Extended ContextMemoryRouter with routing stubs


### PR DESCRIPTION
## Summary
- support new output destinations with `OutputDestination` enum
- update `ContextMemoryRouter` to accept destinations parameter
- write memory to `context_memory/` and add stubs for other routes
- include basic fix tag detection

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6881970a755c83218634816c6daa9f08