### PR TITLE
Add routing configuration

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -149,3 +149,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507240032][cfddc8f][FTR][DATA] Added metadata blocks to all ContextMemory export views
 [2507240201][f46066][FTR][DATA] Added ContextMemoryRouter for routing memory exports
 [2507240217][84726d][FTR][DATA] Extended ContextMemoryRouter with routing stubs
+[2507240225][69644d7][FTR][CFG] Added RoutingConfig and loader

--- a/lib/config/load_routing_config.dart
+++ b/lib/config/load_routing_config.dart
@@ -1,0 +1,14 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'routing_config.dart';
+
+/// Loads [RoutingConfig] from a JSON [path].
+/// Returns `null` if the file does not exist.
+Future<RoutingConfig?> loadRoutingConfig([String path = 'routing_config.json']) async {
+  final file = File(path);
+  if (!await file.exists()) return null;
+  final content = await file.readAsString();
+  final data = jsonDecode(content) as Map<String, dynamic>;
+  return RoutingConfig.fromJson(data);
+}

--- a/lib/config/routing_config.dart
+++ b/lib/config/routing_config.dart
@@ -1,0 +1,29 @@
+import "../export/export_formats.dart";
+import "../routing/context_memory_router.dart";
+
+class RoutingConfig {
+  final List<ExportFormat> formats;
+  final Set<OutputDestination> destinations;
+
+  RoutingConfig({
+    required this.formats,
+    required this.destinations,
+  });
+
+  factory RoutingConfig.fromJson(Map<String, dynamic> json) {
+    final formats = (json['formats'] as List<dynamic>? ?? [])
+        .map((e) => ExportFormat.values
+            .firstWhere((f) => f.name == e, orElse: () => ExportFormat.values.first))
+        .toList();
+    final destinations = (json['destinations'] as List<dynamic>? ?? [])
+        .map((e) => OutputDestination.values
+            .firstWhere((d) => d.name == e, orElse: () => OutputDestination.fileSystem))
+        .toSet();
+    return RoutingConfig(formats: formats, destinations: destinations);
+  }
+
+  Map<String, dynamic> toJson() => {
+        'formats': formats.map((e) => e.name).toList(),
+        'destinations': destinations.map((e) => e.name).toList(),
+      };
+}

--- a/lib/routing/context_memory_router.dart
+++ b/lib/routing/context_memory_router.dart
@@ -5,6 +5,7 @@ import '../models/context_memory.dart';
 import '../export/context_memory_exporter.dart';
 import '../export/export_formats.dart';
 import '../export/exporter_registry.dart';
+import '../config/routing_config.dart';
 
 /// Possible destinations for exported [ContextMemory].
 enum OutputDestination {
@@ -25,10 +26,10 @@ enum OutputDestination {
 class ContextMemoryRouter {
   const ContextMemoryRouter();
 
-  /// Exports [memory] using each of the requested [formats] and dispatches the
-  /// results to all requested [destinations].
-  Future<void> route(ContextMemory memory, List<ExportFormat> formats,
-      Set<OutputDestination> destinations) async {
+  /// Exports [memory] using the formats and destinations defined in [config].
+  Future<void> route(ContextMemory memory, RoutingConfig config) async {
+    final formats = config.formats;
+    final destinations = config.destinations;
     for (final format in formats) {
       final ContextMemoryExporter? exporter =
           ExporterRegistry.getExporter(format);


### PR DESCRIPTION
## Summary
- create `RoutingConfig` model for routing settings
- add loader to parse a routing config JSON file
- update `ContextMemoryRouter.route` to use the new config object
- log update

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688198bac19883219a24f2ae99572961