### PR TITLE
Add argument parsing to context builder CLI

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -153,3 +153,5 @@ This file records all Codex-generated changes and implementations in this projec
 [2507240242][4c3e84][SNC][DOC] Archived all milestone 3 task files and removed milestone3 folder from tasks/
 
 [2507240251][1e8f06][FTR][CLI] Added CLI entry point to trigger context memory build from exported ChatGPT data
+
+[2507240343][b5f5ae][FTR][CLI] Added argument parsing to CLI with support for input path, format, range, and debug toggle

--- a/cli/context_builder.dart
+++ b/cli/context_builder.dart
@@ -1,6 +1,10 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:args/args.dart';
+import 'package:colog_v3/config/app_config.dart';
+import 'package:colog_v3/export/exporter_registry.dart';
+import 'package:colog_v3/export/export_formats.dart';
 import 'package:colog_v3/services/json_loader.dart';
 import 'package:colog_v3/memory/iterative_merge_engine.dart';
 import 'package:colog_v3/services/context_memory_builder.dart';
@@ -8,15 +12,70 @@ import 'package:colog_v3/models/conversation.dart';
 import 'package:colog_v3/models/exchange.dart';
 
 Future<void> main(List<String> args) async {
-  if (args.isEmpty) {
-    print('Usage: dart run cli/context_builder.dart <chatgpt_export.json> [more files...]');
+  final parser = ArgParser()
+    ..addOption('input', abbr: 'i', help: 'Input file or directory', valueHelp: 'path')
+    ..addOption('output-format',
+        abbr: 'o',
+        help: 'Output format',
+        allowed: ['markdown', 'json'],
+        defaultsTo: 'json')
+    ..addOption('start-id', help: 'Start Exchange ID (inclusive)')
+    ..addOption('end-id', help: 'End Exchange ID (inclusive)')
+    ..addFlag('debug', abbr: 'd', help: 'Enable debug logging', defaultsTo: false)
+    ..addFlag('help', abbr: 'h', negatable: false, help: 'Show usage');
+
+  late ArgResults results;
+  try {
+    results = parser.parse(args);
+  } on ArgParserException catch (e) {
+    stderr.writeln(e.message);
+    stderr.writeln(parser.usage);
     exit(1);
+  }
+
+  if (results['help'] == true) {
+    stdout.writeln(parser.usage);
+    return;
+  }
+
+  final inputPath = results['input'] as String?;
+  if (inputPath == null) {
+    stderr.writeln('Error: --input is required');
+    stderr.writeln(parser.usage);
+    exit(1);
+  }
+
+  final entityType = FileSystemEntity.typeSync(inputPath);
+  if (entityType == FileSystemEntityType.notFound) {
+    stderr.writeln('Input path does not exist: $inputPath');
+    exit(1);
+  }
+
+  if (results['debug'] == true) {
+    AppConfig.enableDebug();
   }
 
   stdout.writeln('Context Builder: starting build process');
 
+  final List<String> files = [];
+  if (entityType == FileSystemEntityType.directory) {
+    final dir = Directory(inputPath);
+    for (final f in dir.listSync()) {
+      if (f is File && f.path.toLowerCase().endsWith('.json')) {
+        files.add(f.path);
+      }
+    }
+  } else {
+    files.add(inputPath);
+  }
+
+  if (files.isEmpty) {
+    stderr.writeln('No JSON files found at $inputPath');
+    exit(1);
+  }
+
   final List<Conversation> conversations = [];
-  for (final path in args) {
+  for (final path in files) {
     stdout.writeln('Loading $path ...');
     try {
       final convs = await JsonLoader.loadConversations(path);
@@ -36,18 +95,48 @@ Future<void> main(List<String> args) async {
     exchanges.addAll(conv.exchanges);
   }
 
-  stdout.writeln('Processing ${conversations.length} conversation(s) with ${exchanges.length} exchange(s)...');
+  var startIndex = 0;
+  var endIndex = exchanges.length - 1;
+  final startOpt = results['start-id'] as String?;
+  final endOpt = results['end-id'] as String?;
+  if (startOpt != null) {
+    final val = int.tryParse(startOpt);
+    if (val != null && val >= 0 && val < exchanges.length) {
+      startIndex = val;
+    }
+  }
+  if (endOpt != null) {
+    final val = int.tryParse(endOpt);
+    if (val != null && val >= startIndex && val < exchanges.length) {
+      endIndex = val;
+    }
+  }
+  final filtered = exchanges.sublist(startIndex, endIndex + 1);
+
+  stdout.writeln(
+      'Processing ${conversations.length} conversation(s) with ${filtered.length} exchange(s)...');
 
   final engine = IterativeMergeEngine.fromConfig();
-  final parcel = await engine.mergeAll(exchanges);
+  final parcel = await engine.mergeAll(filtered);
 
   final memory = ContextMemoryBuilder.buildFinalMemory(
     latest: parcel,
-    sourceConversationId: conversations.length == 1 ? conversations.first.title : null,
-    totalExchangeCount: exchanges.length,
+    sourceConversationId:
+        conversations.length == 1 ? conversations.first.title : null,
+    totalExchangeCount: filtered.length,
     mergeStrategy: engine.strategy.name,
   );
 
+  final formatName = results['output-format'] as String;
+  final format = formatName == 'markdown'
+      ? ExportFormat.markdownResume
+      : ExportFormat.structuredJson;
+  final exporter = ExporterRegistry.getExporter(format);
+
   stdout.writeln('Context build complete. Outputting memory to terminal.');
-  stdout.writeln(jsonEncode(memory.toJson()));
+  if (exporter != null) {
+    stdout.writeln(exporter.export(memory));
+  } else {
+    stdout.writeln(jsonEncode(memory.toJson()));
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   file_selector: ^1.0.3
   shared_preferences: ^2.2.2
   intl: ^0.18.1
+  args: ^2.4.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- depend on `args` package for CLI parsing
- extend `context_builder.dart` with ArgParser support
- allow filtering start and end exchange IDs and debug toggle
- output memory as markdown or JSON
- update activity log

## Testing
- `flutter test test/context_memory_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6881ab058a88832195680847f1d6e998