### PR TITLE
Implement CLI memory build summary logging

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -156,3 +156,4 @@ This file records all Codex-generated changes and implementations in this projec
 
 [2507240343][b5f5ae][FTR][CLI] Added argument parsing to CLI with support for input path, format, range, and debug toggle
 [2507240407][2c2ec2][FTR][CLI] Added progress output for CLI context builder with debug mode enhancements
+[2507240416][02047b4][FTR][CLI] Logged final context memory summary and placeholder output path


### PR DESCRIPTION
## Summary
- log context builder start time
- compute skipped indices for malformed exchanges
- log summary stats and placeholder output file location
- log parcel confidence and skipped exchanges when debug enabled
- record activity in CODEX log

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6881b31c20c083219a4fccfd465ed036