### PR TITLE
Add CLI usage help

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -157,3 +157,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507240343][b5f5ae][FTR][CLI] Added argument parsing to CLI with support for input path, format, range, and debug toggle
 [2507240407][2c2ec2][FTR][CLI] Added progress output for CLI context builder with debug mode enhancements
 [2507240416][02047b4][FTR][CLI] Logged final context memory summary and placeholder output path
+[2507240435][c5fae9d][FTR][CLI] Added CLI help instructions and example usage output

--- a/cli/context_builder.dart
+++ b/cli/context_builder.dart
@@ -11,6 +11,26 @@ import 'package:colog_v3/services/context_memory_builder.dart';
 import 'package:colog_v3/models/conversation.dart';
 import 'package:colog_v3/models/exchange.dart';
 
+const String _usageGuide = '''
+Builds a ContextMemory from exported ChatGPT conversation JSON.
+
+Usage: dart cli/context_builder.dart --input <file|directory> [options]
+
+Required arguments:
+  --input <file|directory>    Input file or directory
+
+Optional arguments:
+  --output-format <json|markdown>  (default: json)
+  --start-id <exchangeId>     Start Exchange ID
+  --end-id <exchangeId>       End Exchange ID
+  --debug                     Enable debug logging
+  --help                      Show this usage information
+
+Example invocations:
+  dart cli/context_builder.dart --input ./exports/chat.json
+  dart cli/context_builder.dart --input ./exports/ --output-format markdown --debug
+''';
+
 Future<void> main(List<String> args) async {
   final parser = ArgParser()
     ..addOption(
@@ -41,19 +61,19 @@ Future<void> main(List<String> args) async {
     results = parser.parse(args);
   } on ArgParserException catch (e) {
     stderr.writeln(e.message);
-    stderr.writeln(parser.usage);
+    stdout.writeln(_usageGuide);
     exit(1);
   }
 
-  if (results['help'] == true) {
-    stdout.writeln(parser.usage);
+  if (results['help'] == true || args.isEmpty) {
+    stdout.writeln(_usageGuide);
     return;
   }
 
   final inputPath = results['input'] as String?;
   if (inputPath == null) {
     stderr.writeln('Error: --input is required');
-    stderr.writeln(parser.usage);
+    stdout.writeln(_usageGuide);
     exit(1);
   }
 


### PR DESCRIPTION
## Summary
- include help text and examples in CLI context builder
- log CLI help instructions in activity log

## Testing
- `dart --version`

------
https://chatgpt.com/codex/tasks/task_b_6881b751fc548321a6c0276560f75c82