### PR TITLE
Add output directory support for batch mode

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -161,3 +161,4 @@ This file records all Codex-generated changes and implementations in this projec
 
 [2507240641][cff1b83][FTR][BATCH] Added batch mode to process all .json files in a directory via CLI
 [2507240649][1fee53][FTR][BATCH] Added conversation filtering by tags, date range, and title keywords in batch mode
+[2507240702][be0a06][FTR][BATCH] Wrote each ContextMemory to structured output directory based on input filename and format


### PR DESCRIPTION
## Summary
- support `--output-dir` CLI option
- require output directory when input is a directory
- write each output context memory file alongside a success message
- log new feature

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6881d9a549708321bbc77e315b9fbbd0