### PR TITLE
Add batch summary logging

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -162,3 +162,5 @@ This file records all Codex-generated changes and implementations in this projec
 [2507240641][cff1b83][FTR][BATCH] Added batch mode to process all .json files in a directory via CLI
 [2507240649][1fee53][FTR][BATCH] Added conversation filtering by tags, date range, and title keywords in batch mode
 [2507240702][be0a06][FTR][BATCH] Wrote each ContextMemory to structured output directory based on input filename and format
+
+[2507240755][c8d9381][FTR][BATCH] Logged end-of-batch summary with conversation, exchange, and file statistics


### PR DESCRIPTION
## Summary
- implement per-file stats collection in CLI batch mode
- add final batch summary output after all files processed
- log batch summary feature

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6881e5d48bbc8321ab27e1cca0101dd9