### PR TITLE
Implement graceful error handling for batch conversation processing

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -164,3 +164,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507240702][be0a06][FTR][BATCH] Wrote each ContextMemory to structured output directory based on input filename and format
 
 [2507240755][c8d9381][FTR][BATCH] Logged end-of-batch summary with conversation, exchange, and file statistics
+[2507240826][19772de][ERR][BATCH] Added graceful error handling and reporting for failed conversations during batch processing


### PR DESCRIPTION
## Summary
- add optional `--fail-fast` flag to batch context builder CLI
- collect failures during batch runs and show them in batch summary
- wrap per-file processing with error handling and return stats or failure info
- log new behavior in CODEX activity log

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_b_6881ec45254c8321b63b4bcfbb26fd7d