### PR TITLE
Add diff preview for manual review

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -166,3 +166,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507240755][c8d9381][FTR][BATCH] Logged end-of-batch summary with conversation, exchange, and file statistics
 [2507240826][19772de][ERR][BATCH] Added graceful error handling and reporting for failed conversations during batch processing
 [2507240842][ecb1ae][FTR][REVIEW] Added --manual-review flag to enable review before merging ContextParcels
+[2507242033][e8da75e][FTR][REVIEW] Added inline diff preview of ContextParcel changes during manual review

--- a/lib/memory/iterative_merge_engine.dart
+++ b/lib/memory/iterative_merge_engine.dart
@@ -74,7 +74,7 @@ class IterativeMergeEngine {
           continue;
         }
         if (AppConfig.manualReview) {
-          reviewed = await ManualReviewer.review(result);
+          reviewed = await ManualReviewer.review(result, previousContext);
           if (reviewed == null) {
             index++;
             continue;

--- a/lib/services/manual_reviewer.dart
+++ b/lib/services/manual_reviewer.dart
@@ -2,14 +2,25 @@ import 'dart:convert';
 import 'dart:io';
 
 import '../models/context_parcel.dart';
+import '../config/app_config.dart';
 
 /// Provides interactive review of ContextParcel objects before merging.
 class ManualReviewer {
-  /// Prompts the user to accept, reject, or edit the [parcel].
+  /// Prompts the user to accept, reject, or edit the [parcel]. Optionally
+  /// compares the parcel against [baseline] and shows a unified diff.
   /// Returns the parcel to merge or `null` if rejected.
-  static Future<ContextParcel?> review(ContextParcel parcel) async {
-    stdout.writeln('\nProposed ContextParcel:');
-    stdout.writeln(JsonEncoder.withIndent('  ').convert(parcel.toJson()));
+  static Future<ContextParcel?> review(
+    ContextParcel parcel, [ContextParcel? baseline]) async {
+    if (baseline != null && baseline.summary.isNotEmpty) {
+      final oldJson = JsonEncoder.withIndent('  ').convert(baseline.toJson());
+      final newJson = JsonEncoder.withIndent('  ').convert(parcel.toJson());
+      final diff = _generateUnifiedDiff(oldJson, newJson);
+      stdout.writeln('\nProposed ContextParcel diff:');
+      stdout.writeln(_truncate(diff));
+    } else {
+      stdout.writeln('\nProposed ContextParcel:');
+      stdout.writeln(JsonEncoder.withIndent('  ').convert(parcel.toJson()));
+    }
     stdout.write('[A]ccept / [R]eject / [E]dit: ');
     final choice = stdin.readLineSync()?.trim().toLowerCase();
     switch (choice) {
@@ -49,5 +60,44 @@ class ManualReviewer {
         stdout.writeln('Accepted.');
         return parcel;
     }
+  }
+
+  /// Creates a naive unified diff between [oldText] and [newText].
+  static String _generateUnifiedDiff(String oldText, String newText) {
+    final oldLines = oldText.split('\n');
+    final newLines = newText.split('\n');
+    final buffer = StringBuffer();
+    var i = 0;
+    var j = 0;
+    while (i < oldLines.length || j < newLines.length) {
+      final oldLine = i < oldLines.length ? oldLines[i] : null;
+      final newLine = j < newLines.length ? newLines[j] : null;
+      if (oldLine != null && newLine != null && oldLine == newLine) {
+        buffer.writeln('  $oldLine');
+        i++;
+        j++;
+      } else {
+        if (oldLine != null) {
+          buffer.writeln('- $oldLine');
+          i++;
+        }
+        if (newLine != null) {
+          buffer.writeln('+ $newLine');
+          j++;
+        }
+      }
+    }
+    return buffer.toString();
+  }
+
+  /// Truncates [diff] for non-debug mode to avoid flooding the terminal.
+  static String _truncate(String diff) {
+    final lines = diff.split('\n');
+    if (!AppConfig.debugMode && lines.length > 40) {
+      final head = lines.take(20).join('\n');
+      final tail = lines.skip(lines.length - 20).join('\n');
+      return '$head\n... (${lines.length - 40} lines truncated) ...\n$tail';
+    }
+    return diff;
   }
 }


### PR DESCRIPTION
## Summary
- show a unified diff between the proposed ContextParcel and existing memory during manual review
- pass previous context into the manual reviewer
- log the new feature

## Testing
- `dart format lib/services/manual_reviewer.dart lib/memory/iterative_merge_engine.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688297b172c88321a206a6cc68bba0e5