### PR TITLE
Add manual review CLI flag

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -167,3 +167,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507240826][19772de][ERR][BATCH] Added graceful error handling and reporting for failed conversations during batch processing
 [2507240842][ecb1ae][FTR][REVIEW] Added --manual-review flag to enable review before merging ContextParcels
 [2507242033][e8da75e][FTR][REVIEW] Added inline diff preview of ContextParcel changes during manual review
+[2507242105][9b5d95c][FTR][CFG] Added --manual-review CLI flag to toggle user review of ContextParcels

--- a/cli/context_builder.dart
+++ b/cli/context_builder.dart
@@ -31,6 +31,8 @@ Optional arguments:
                               Only include conversations whose titles contain
                               any keyword
   --debug                     Enable debug logging
+  --fail-fast                 Abort batch on first error
+  --manual-review             Enable manual review of each ContextParcel
   --help                      Show this usage information
 
 Example invocations:

--- a/test/config/app_config_test.dart
+++ b/test/config/app_config_test.dart
@@ -9,5 +9,12 @@ void main() {
       AppConfig.enableDebug();
       expect(AppConfig.debugMode, isTrue);
     });
+
+    test('toggle manual review mode', () {
+      AppConfig.disableManualReview();
+      expect(AppConfig.manualReview, isFalse);
+      AppConfig.enableManualReview();
+      expect(AppConfig.manualReview, isTrue);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- document the `--manual-review` flag in CLI help
- test AppConfig manual review toggle
- log the CLI flag addition

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68829f4be76c8321a8f217a3a0479391