### PR TITLE
Enforce manual review flag gating

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -168,3 +168,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507240842][ecb1ae][FTR][REVIEW] Added --manual-review flag to enable review before merging ContextParcels
 [2507242033][e8da75e][FTR][REVIEW] Added inline diff preview of ContextParcel changes during manual review
 [2507242105][9b5d95c][FTR][CFG] Added --manual-review CLI flag to toggle user review of ContextParcels
+[2507242118][b26c8d0][REF][REVIEW] Enforced --manual-review toggle across all user interaction and edit tracking logic

--- a/lib/memory/iterative_merge_engine.dart
+++ b/lib/memory/iterative_merge_engine.dart
@@ -32,6 +32,10 @@ class IterativeMergeEngine {
 
     if (AppConfig.debugMode) {
       print('IterativeMergeEngine: Using strategy $strategy');
+      print(
+        'IterativeMergeEngine: manual review mode is '
+        '${AppConfig.manualReview ? 'enabled' : 'disabled'}',
+      );
     }
     final total = exchanges.length;
     for (final exchange in exchanges) {
@@ -74,6 +78,9 @@ class IterativeMergeEngine {
           continue;
         }
         if (AppConfig.manualReview) {
+          if (AppConfig.debugMode) {
+            print('IterativeMergeEngine: launching manual review for exchange $index');
+          }
           reviewed = await ManualReviewer.review(
             result,
             index,

--- a/lib/services/manual_reviewer.dart
+++ b/lib/services/manual_reviewer.dart
@@ -15,6 +15,15 @@ class ManualReviewer {
     int exchangeId, [
     ContextParcel? baseline,
   ]) async {
+    if (!AppConfig.manualReview) {
+      if (AppConfig.debugMode) {
+        stdout.writeln('ManualReviewer: manual review disabled');
+      }
+      return parcel;
+    }
+    if (AppConfig.debugMode) {
+      stdout.writeln('ManualReviewer: reviewing exchange $exchangeId');
+    }
     if (baseline != null && baseline.summary.isNotEmpty) {
       final oldJson = JsonEncoder.withIndent('  ').convert(baseline.toJson());
       final newJson = JsonEncoder.withIndent('  ').convert(parcel.toJson());


### PR DESCRIPTION
## Summary
- honor `--manual-review` flag inside `ManualReviewer.review`
- log manual review mode in `IterativeMergeEngine`
- log when manual review launches during merge
- record enforcement in `CODEXLOG_CURRENT.md`

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6882a1bf598c832186e3e86cb893d9ac