### PR TITLE
Add metadata fields to ContextParcels

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -170,3 +170,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507242105][9b5d95c][FTR][CFG] Added --manual-review CLI flag to toggle user review of ContextParcels
 [2507242118][b26c8d0][REF][REVIEW] Enforced --manual-review toggle across all user interaction and edit tracking logic
 [2507242125][c66fab1][SNC][DOC] Marked all tasks complete and archived milestone 4 task files to archive/tasks/
+[2507242140][ac4ced][FTR][DATA] Added feature, system, and module metadata to ContextParcels

--- a/cli/context_builder.dart
+++ b/cli/context_builder.dart
@@ -30,6 +30,9 @@ Optional arguments:
   --title-keywords <kw1,kw2,...>
                               Only include conversations whose titles contain
                               any keyword
+  --feature <name>            Feature tag for generated memory
+  --system <name>             System/component name
+  --module <name>             Module identifier
   --debug                     Enable debug logging
   --fail-fast                 Abort batch on first error
   --manual-review             Enable manual review of each ContextParcel
@@ -68,6 +71,9 @@ Future<void> main(List<String> args) async {
     ..addOption('to-date', help: 'End date yyyy-mm-dd')
     ..addOption('title-keywords',
         help: 'Comma-separated conversation title keywords')
+    ..addOption('feature', help: 'Feature tag for generated memory')
+    ..addOption('system', help: 'System/component name')
+    ..addOption('module', help: 'Module identifier')
     ..addFlag(
       'debug',
       abbr: 'd',
@@ -362,6 +368,26 @@ Future<({ _FileStats? stats, String? failed })> _processFile(
       totalExchangeCount: filtered.length,
       mergeStrategy: engine.strategy.name,
     );
+
+    final feature = results['feature'] as String?;
+    final system = results['system'] as String?;
+    final module = results['module'] as String?;
+    if (feature != null || system != null || module != null) {
+      for (var i = 0; i < memory.parcels.length; i++) {
+        final p = memory.parcels[i];
+        memory.parcels[i] = ContextParcel(
+          summary: p.summary,
+          mergeHistory: p.mergeHistory,
+          tags: p.tags,
+          assumptions: p.assumptions,
+          confidence: p.confidence,
+          manualEdits: p.manualEdits,
+          feature: feature ?? p.feature,
+          system: system ?? p.system,
+          module: module ?? p.module,
+        );
+      }
+    }
 
     final formatName = results['output-format'] as String;
     final format = formatName == 'markdown'

--- a/lib/models/context_parcel.dart
+++ b/lib/models/context_parcel.dart
@@ -19,6 +19,15 @@ class ContextParcel {
   /// Records any manual edits applied during merge review.
   final List<ManualEdit> manualEdits;
 
+  /// Short feature identifier this parcel relates to (e.g. "search").
+  final String? feature;
+
+  /// Optional high-level system or component name.
+  final String? system;
+
+  /// Optional file or logical module identifier.
+  final String? module;
+
   ContextParcel({
     required this.summary,
     required this.mergeHistory,
@@ -26,6 +35,9 @@ class ContextParcel {
     this.assumptions = const [],
     this.confidence = const {},
     this.manualEdits = const [],
+    this.feature,
+    this.system,
+    this.module,
   });
 
   factory ContextParcel.fromJson(Map<String, dynamic> json) => ContextParcel(
@@ -38,6 +50,9 @@ class ContextParcel {
         manualEdits: (json['manualEdits'] as List<dynamic>? ?? [])
             .map((e) => ManualEdit.fromJson(Map<String, dynamic>.from(e)))
             .toList(),
+        feature: json['feature'] as String?,
+        system: json['system'] as String?,
+        module: json['module'] as String?,
       );
 
   Map<String, dynamic> toJson() => {
@@ -47,6 +62,9 @@ class ContextParcel {
         'assumptions': assumptions,
         'confidence': confidence,
         'manualEdits': manualEdits.map((e) => e.toJson()).toList(),
+        if (feature != null) 'feature': feature,
+        if (system != null) 'system': system,
+        if (module != null) 'module': module,
       };
 
   /// Returns true if this parcel conveys essentially the same

--- a/lib/services/manual_reviewer.dart
+++ b/lib/services/manual_reviewer.dart
@@ -47,6 +47,12 @@ class ManualReviewer {
         final tagsInput = stdin.readLineSync();
         stdout.write('Edit assumptions CSV (leave blank to keep): ');
         final assumptionsInput = stdin.readLineSync();
+        stdout.write('Edit feature (leave blank to keep): ');
+        final featureInput = stdin.readLineSync();
+        stdout.write('Edit system (leave blank to keep): ');
+        final systemInput = stdin.readLineSync();
+        stdout.write('Edit module (leave blank to keep): ');
+        final moduleInput = stdin.readLineSync();
         final edited = ContextParcel(
           summary: newSummary != null && newSummary.trim().isNotEmpty
               ? newSummary.trim()
@@ -69,6 +75,15 @@ class ManualReviewer {
                   : parcel.assumptions,
           confidence: parcel.confidence,
           manualEdits: parcel.manualEdits,
+          feature: featureInput != null && featureInput.trim().isNotEmpty
+              ? featureInput.trim()
+              : parcel.feature,
+          system: systemInput != null && systemInput.trim().isNotEmpty
+              ? systemInput.trim()
+              : parcel.system,
+          module: moduleInput != null && moduleInput.trim().isNotEmpty
+              ? moduleInput.trim()
+              : parcel.module,
         );
 
         final record = ManualEdit(
@@ -84,6 +99,9 @@ class ManualReviewer {
           assumptions: edited.assumptions,
           confidence: edited.confidence,
           manualEdits: [...parcel.manualEdits, record],
+          feature: edited.feature,
+          system: edited.system,
+          module: edited.module,
         );
       default:
         stdout.writeln('Accepted.');

--- a/test/context_memory_test.dart
+++ b/test/context_memory_test.dart
@@ -14,8 +14,21 @@ void main() {
       );
       final memory = ContextMemory(
         parcels: [
-          ContextParcel(summary: 'a', mergeHistory: [1]),
-          ContextParcel(summary: 'b edited', mergeHistory: [2], manualEdits: [edit]),
+          ContextParcel(
+            summary: 'a',
+            mergeHistory: [1],
+            feature: 'search',
+            system: 'parser',
+            module: 'ContextRouter',
+          ),
+          ContextParcel(
+            summary: 'b edited',
+            mergeHistory: [2],
+            manualEdits: [edit],
+            feature: 'search',
+            system: 'parser',
+            module: 'ContextRouter',
+          ),
         ],
         generatedAt: DateTime.parse('2025-07-23T00:00:00Z'),
         sourceConversationId: 'conv1',
@@ -37,6 +50,9 @@ void main() {
       expect(roundTrip.completeness, 'partial');
       expect(roundTrip.limitations, 'some missing data');
       expect(roundTrip.generatedAt, DateTime.parse('2025-07-23T00:00:00Z'));
+      expect(roundTrip.parcels.first.feature, 'search');
+      expect(roundTrip.parcels.first.system, 'parser');
+      expect(roundTrip.parcels.first.module, 'ContextRouter');
     });
   });
 }

--- a/test/memory/context_memory_builder_test.dart
+++ b/test/memory/context_memory_builder_test.dart
@@ -7,8 +7,20 @@ import '../../lib/services/context_memory_builder.dart';
 void main() {
   group('ContextMemoryBuilder', () {
     test('builds memory with history and metadata', () {
-      final latest = ContextParcel(summary: 'final', mergeHistory: [0, 1]);
-      final prev = ContextParcel(summary: 'prev', mergeHistory: [0]);
+      final latest = ContextParcel(
+        summary: 'final',
+        mergeHistory: [0, 1],
+        feature: 'search',
+        system: 'parser',
+        module: 'ContextRouter',
+      );
+      final prev = ContextParcel(
+        summary: 'prev',
+        mergeHistory: [0],
+        feature: 'search',
+        system: 'parser',
+        module: 'ContextRouter',
+      );
       final ts = DateTime.parse('2025-07-24T00:00:00Z');
       final memory = ContextMemoryBuilder.buildFinalMemory(
         latest: latest,
@@ -25,6 +37,9 @@ void main() {
       expect(memory.parcels.length, 2);
       expect(memory.parcels.first.summary, 'prev');
       expect(memory.parcels.last.summary, 'final');
+      expect(memory.parcels.first.feature, 'search');
+      expect(memory.parcels.first.system, 'parser');
+      expect(memory.parcels.first.module, 'ContextRouter');
       expect(memory.sourceConversationId, 'c1');
       expect(memory.exchangeCount, 2);
       expect(memory.strategy, 'default');


### PR DESCRIPTION
## Summary
- allow specifying `feature`, `system`, and `module` metadata in `ContextParcel`
- prompt for the new fields during manual review
- support --feature/--system/--module options in the CLI and apply them to built memories
- update tests for serialization and builder
- log new functionality

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6882a70cb4bc8321aa748fadcf52fd86