### PR TITLE
Implement ContextRouter for metadata routing

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -171,3 +171,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507242118][b26c8d0][REF][REVIEW] Enforced --manual-review toggle across all user interaction and edit tracking logic
 [2507242125][c66fab1][SNC][DOC] Marked all tasks complete and archived milestone 4 task files to archive/tasks/
 [2507242140][ac4ced][FTR][DATA] Added feature, system, and module metadata to ContextParcels
+[2507242154][0c38af7][FTR][TST] Implemented ContextRouter with metadata grouping and tests

--- a/lib/routing/context_router.dart
+++ b/lib/routing/context_router.dart
@@ -1,0 +1,94 @@
+import '../models/context_memory.dart';
+import '../models/context_parcel.dart';
+
+/// Keys used to determine routing priority.
+enum RoutingKey { feature, system, module }
+
+/// Holds the results of routing operations.
+class RoutingResult {
+  final Map<String, List<ContextParcel>> byFeature;
+  final Map<String, List<ContextParcel>> bySystem;
+  final Map<String, List<ContextParcel>> byModule;
+  final Map<String, List<ContextParcel>> byPriority;
+  final List<ContextParcel> unassigned;
+
+  RoutingResult({
+    required this.byFeature,
+    required this.bySystem,
+    required this.byModule,
+    required this.byPriority,
+    required this.unassigned,
+  });
+}
+
+/// Groups ContextParcels or ContextMemory objects by metadata fields.
+class ContextRouter {
+  final List<RoutingKey> priority;
+
+  ContextRouter({List<RoutingKey>? priority})
+      : priority = priority ??
+            const [RoutingKey.module, RoutingKey.feature, RoutingKey.system];
+
+  /// Routes [parcels] according to the configured [priority]. Returns maps of
+  /// parcels grouped by feature, system, module, and the chosen priority order.
+  RoutingResult routeParcels(List<ContextParcel> parcels) {
+    final byFeature = <String, List<ContextParcel>>{};
+    final bySystem = <String, List<ContextParcel>>{};
+    final byModule = <String, List<ContextParcel>>{};
+    final byPriority = <String, List<ContextParcel>>{};
+    final unassigned = <ContextParcel>[];
+
+    for (final parcel in parcels) {
+      // Record all groupings regardless of priority
+      if (parcel.feature != null && parcel.feature!.trim().isNotEmpty) {
+        byFeature.putIfAbsent(parcel.feature!, () => []).add(parcel);
+      }
+      if (parcel.system != null && parcel.system!.trim().isNotEmpty) {
+        bySystem.putIfAbsent(parcel.system!, () => []).add(parcel);
+      }
+      if (parcel.module != null && parcel.module!.trim().isNotEmpty) {
+        byModule.putIfAbsent(parcel.module!, () => []).add(parcel);
+      }
+
+      // Route to a single priority bucket
+      String? key;
+      for (final field in priority) {
+        key = _valueFor(field, parcel);
+        if (key != null && key.trim().isNotEmpty) {
+          break;
+        }
+      }
+      if (key == null || key.trim().isEmpty) {
+        unassigned.add(parcel);
+      } else {
+        byPriority.putIfAbsent(key, () => []).add(parcel);
+      }
+    }
+
+    return RoutingResult(
+      byFeature: byFeature,
+      bySystem: bySystem,
+      byModule: byModule,
+      byPriority: byPriority,
+      unassigned: unassigned,
+    );
+  }
+
+  /// Routes all parcels contained in [memories].
+  RoutingResult routeMemories(List<ContextMemory> memories) {
+    final parcels = memories.expand((m) => m.parcels).toList();
+    return routeParcels(parcels);
+  }
+
+  String? _valueFor(RoutingKey key, ContextParcel parcel) {
+    switch (key) {
+      case RoutingKey.feature:
+        return parcel.feature;
+      case RoutingKey.system:
+        return parcel.system;
+      case RoutingKey.module:
+        return parcel.module;
+    }
+  }
+}
+

--- a/test/routing/context_router_test.dart
+++ b/test/routing/context_router_test.dart
@@ -1,0 +1,57 @@
+import 'package:test/test.dart';
+
+import '../../lib/models/context_parcel.dart';
+import '../../lib/models/context_memory.dart';
+import '../../lib/routing/context_router.dart';
+
+void main() {
+  group('ContextRouter', () {
+    test('routes parcels by priority and groups metadata', () {
+      final parcels = [
+        ContextParcel(
+          summary: 'a',
+          mergeHistory: [0],
+          feature: 'f1',
+          module: 'm1',
+        ),
+        ContextParcel(
+          summary: 'b',
+          mergeHistory: [1],
+          feature: 'f1',
+        ),
+        ContextParcel(
+          summary: 'c',
+          mergeHistory: [2],
+          system: 's1',
+        ),
+        ContextParcel(
+          summary: 'd',
+          mergeHistory: [3],
+        ),
+      ];
+      final router = ContextRouter(priority: [RoutingKey.module, RoutingKey.feature]);
+      final result = router.routeParcels(parcels);
+
+      expect(result.byModule['m1']!.length, 1);
+      expect(result.byFeature['f1']!.length, 2);
+      expect(result.bySystem['s1']!.length, 1);
+      expect(result.byPriority['m1']!.first.summary, 'a');
+      expect(result.byPriority['f1']!.length, 1);
+      expect(result.unassigned.length, 1);
+    });
+
+    test('routes memories by flattening parcels', () {
+      final mem1 = ContextMemory(parcels: [
+        ContextParcel(summary: 'x', mergeHistory: [0], feature: 'fx'),
+      ]);
+      final mem2 = ContextMemory(parcels: [
+        ContextParcel(summary: 'y', mergeHistory: [1]),
+      ]);
+      final router = ContextRouter();
+      final result = router.routeMemories([mem1, mem2]);
+      expect(result.byFeature['fx']!.length, 1);
+      expect(result.unassigned.length, 1);
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `ContextRouter` service to route context parcels by feature/system/module
- support routing priority configuration and collect unassigned items
- unit tests for new routing logic
- update CODEX log

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6882aac0d80c8321aa383cfde24da9ba