### PR TITLE
Implement RoutedContextExporter

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -173,3 +173,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507242140][ac4ced][FTR][DATA] Added feature, system, and module metadata to ContextParcels
 [2507242154][0c38af7][FTR][TST] Implemented ContextRouter with metadata grouping and tests
 [2507242215][66d51e][FTR][TST] Added manual routing override and ambiguity detection
+[2507242231][9d48493][FTR][TST] Added RoutedContextExporter with folder export tests

--- a/lib/export/routed_context_exporter.dart
+++ b/lib/export/routed_context_exporter.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import '../models/context_parcel.dart';
+import '../routing/context_router.dart';
+
+/// Utility that writes routed [ContextParcel]s to a structured folder layout.
+///
+/// Output structure:
+/// ```
+/// <base>/by_feature/<feature_name>/context.md
+/// <base>/by_module/<module_name>/context.md
+/// ```
+class RoutedContextExporter {
+  final String basePath;
+
+  RoutedContextExporter({this.basePath = 'export/context'});
+
+  /// Writes [result] groups to the filesystem.
+  Future<void> export(RoutingResult result, {bool includeUnassigned = false}) async {
+    await _writeGroups(result.byFeature, 'by_feature');
+    await _writeGroups(result.byModule, 'by_module');
+    if (includeUnassigned) {
+      await _writeGroups({'unassigned': result.unassigned}, 'misc');
+    }
+  }
+
+  Future<void> _writeGroups(Map<String, List<ContextParcel>> groups, String subdir) async {
+    for (final entry in groups.entries) {
+      if (entry.value.isEmpty) continue;
+      final dirName = _sanitizeName(entry.key);
+      final dir = Directory('$basePath/$subdir/$dirName');
+      if (!dir.existsSync()) {
+        dir.createSync(recursive: true);
+      }
+      final file = File('${dir.path}/context.md');
+      final buffer = StringBuffer()
+        ..writeln('# ${entry.key}')
+        ..writeln();
+      for (var i = 0; i < entry.value.length; i++) {
+        buffer.writeln('## Entry ${i + 1}');
+        buffer.writeln(_formatParcel(entry.value[i]));
+        buffer.writeln();
+      }
+      await file.writeAsString(buffer.toString().trim());
+    }
+  }
+
+  String _sanitizeName(String name) =>
+      name.replaceAll(RegExp(r'[\\/\:\*\?"<>\|]'), '').replaceAll(' ', '_');
+
+  String _formatParcel(ContextParcel parcel) {
+    final buffer = StringBuffer(parcel.summary.trim());
+    if (parcel.tags.isNotEmpty) {
+      buffer.writeln();
+      buffer.writeln('_Tags:_ ${parcel.tags.join(', ')}');
+    }
+    return buffer.toString().trim();
+  }
+}

--- a/test/export/routed_context_exporter_test.dart
+++ b/test/export/routed_context_exporter_test.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../../lib/export/routed_context_exporter.dart';
+import '../../lib/models/context_parcel.dart';
+import '../../lib/routing/context_router.dart';
+
+void main() {
+  group('RoutedContextExporter', () {
+    test('exports context by feature and module', () async {
+      final parcels = [
+        ContextParcel(summary: 'fa', mergeHistory: [0], feature: 'feat', module: 'modA'),
+        ContextParcel(summary: 'fb', mergeHistory: [1], feature: 'feat'),
+        ContextParcel(summary: 'ma', mergeHistory: [2], module: 'modB'),
+        ContextParcel(summary: 'x', mergeHistory: [3]),
+      ];
+      final router = ContextRouter();
+      final result = router.routeParcels(parcels);
+
+      final temp = Directory.systemTemp.createTempSync('routed_export_test');
+      final exporter = RoutedContextExporter(basePath: temp.path);
+      await exporter.export(result);
+
+      final featDir = Directory('${temp.path}/by_feature/feat');
+      final modADir = Directory('${temp.path}/by_module/modA');
+      final modBDir = Directory('${temp.path}/by_module/modB');
+      expect(featDir.existsSync(), isTrue);
+      expect(modADir.existsSync(), isTrue);
+      expect(modBDir.existsSync(), isTrue);
+
+      final featFile = File('${featDir.path}/context.md');
+      final modAFile = File('${modADir.path}/context.md');
+      expect(featFile.existsSync(), isTrue);
+      expect(modAFile.existsSync(), isTrue);
+
+      final featContent = featFile.readAsStringSync();
+      expect(featContent.contains('fa'), isTrue);
+      expect(featContent.contains('fb'), isTrue);
+      expect(featContent.contains('x'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `RoutedContextExporter` for writing routed context to folders
- test exporter logic for feature and module groups
- log new feature

## Testing
- `dart test` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_b_6882b2ef9c84832191b3ac34b4b3eea3