### PR TITLE
Define context memory tagging schema

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -175,3 +175,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507242215][66d51e][FTR][TST] Added manual routing override and ambiguity detection
 [2507242231][9d48493][FTR][TST] Added RoutedContextExporter with folder export tests
 [2507242254][460636a][DOC] Documented routed context output format
+[2507242327][202dd0][FTR][DOC] Added ContextTag enum and tagging schema documentation

--- a/docs/context_tagging_schema.md
+++ b/docs/context_tagging_schema.md
@@ -1,0 +1,32 @@
+# Context Tagging Schema
+
+ContextParcels may include inline tags to mark the role or purpose of a line. Tags make it easier for tools and reviewers to locate key information.
+
+## Supported Tags
+
+| Tag | Meaning |
+| --- | ------- |
+| `[DECISION]` | Captures important project or architectural decisions |
+| `[BUG_FIX]` | Describes the nature of a fix or its discussion |
+| `[ARCH_NOTE]` | Denotes architectural commentary or notes |
+| `[QUESTION]` | Marks a question raised in the conversation |
+| `[ANSWER]` | Indicates an explicit answer or solution |
+| `[PLAN]` | Outlines a plan or next steps |
+| `[BLOCKER]` | Identifies something preventing progress |
+
+## Format
+
+- Tags appear at the **start of a line**.
+- The tag text is wrapped in square brackets with uppercase letters and underscores.
+- Example: `[DECISION] Switch to gRPC for service communication.`
+
+A line without a recognized tag is treated as regular summary text.
+
+## Examples
+
+```text
+[DECISION] Adopt repository pattern for data access.
+[BUG_FIX] Fixed null pointer when user ID is missing.
+[ARCH_NOTE] Parser layer separated from UI for testing.
+[PLAN] Implement caching next sprint.
+```

--- a/lib/models/context_tag.dart
+++ b/lib/models/context_tag.dart
@@ -1,0 +1,63 @@
+/// Defines supported inline tags for ContextParcel summaries.
+///
+/// Tags label specific parts of the conversation memory so other
+/// tools can filter or highlight them.
+
+enum ContextTag {
+  /// Captures important project or architectural decisions.
+  decision('DECISION', 'Captures important project or architectural decisions'),
+
+  /// Describes the nature of a bug fix or its discussion.
+  bugFix('BUG_FIX', 'Describes the nature of a fix or its discussion'),
+
+  /// Denotes architectural commentary or notes.
+  archNote('ARCH_NOTE', 'Denotes architectural commentary'),
+
+  /// Marks a question raised in the conversation.
+  question('QUESTION', 'Marks a question raised in the conversation'),
+
+  /// Marks an explicit answer or solution provided.
+  answer('ANSWER', 'Marks an explicit answer or solution provided'),
+
+  /// Outlines a plan or next steps.
+  plan('PLAN', 'Outlines a plan or next steps'),
+
+  /// Indicates something blocking progress.
+  blocker('BLOCKER', 'Indicates something blocking progress');
+
+  /// Raw label used inside brackets, e.g. `[DECISION]`.
+  final String label;
+
+  /// Human-readable description of the tag purpose.
+  final String description;
+
+  const ContextTag(this.label, this.description);
+
+  /// Returns the bracketed representation, e.g. `[DECISION]`.
+  String get bracketed => '[$label]';
+
+  static final RegExp _inlinePattern = RegExp(r'^\[([A-Z_]+)\]');
+
+  /// Parses the tag at the beginning of [line]. Returns `null` if not found
+  /// or if the tag name is unrecognized.
+  static ContextTag? fromLine(String line) {
+    final match = _inlinePattern.firstMatch(line.trim());
+    if (match == null) return null;
+    final name = match.group(1);
+    for (final tag in ContextTag.values) {
+      if (tag.label == name) return tag;
+    }
+    return null;
+  }
+
+  /// Returns `true` if [line] begins with a recognized context tag.
+  static bool isValidTaggedLine(String line) => fromLine(line) != null;
+
+  /// Returns `true` if [name] matches one of the supported tag labels.
+  static bool isValidTagName(String name) {
+    for (final tag in ContextTag.values) {
+      if (tag.label == name) return true;
+    }
+    return false;
+  }
+}

--- a/test/models/context_tag_test.dart
+++ b/test/models/context_tag_test.dart
@@ -1,0 +1,27 @@
+import 'package:test/test.dart';
+
+import '../../lib/models/context_tag.dart';
+
+void main() {
+  group('ContextTag', () {
+    test('parses valid tagged line', () {
+      final tag = ContextTag.fromLine('[BUG_FIX] Fixed issue');
+      expect(tag, ContextTag.bugFix);
+    });
+
+    test('returns null for untagged line', () {
+      final tag = ContextTag.fromLine('No tag here');
+      expect(tag, isNull);
+    });
+
+    test('validates tag names', () {
+      expect(ContextTag.isValidTagName('DECISION'), isTrue);
+      expect(ContextTag.isValidTagName('UNKNOWN'), isFalse);
+    });
+
+    test('detects tagged lines', () {
+      expect(ContextTag.isValidTaggedLine('[PLAN] Something'), isTrue);
+      expect(ContextTag.isValidTaggedLine('PLAN Something'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `ContextTag` enum with validation helpers
- document context tagging schema
- test context tag parsing and validation

## Testing
- `dart` command unavailable so tests could not run

------
https://chatgpt.com/codex/tasks/task_b_6882c08c75948321b19b231155847bbc