### PR TITLE
Implement inline tag detection in ContextParcel

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -176,3 +176,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507242231][9d48493][FTR][TST] Added RoutedContextExporter with folder export tests
 [2507242254][460636a][DOC] Documented routed context output format
 [2507242327][202dd0][FTR][DOC] Added ContextTag enum and tagging schema documentation
+[2507242348][b645f5c][FTR][TST] Added inline tag extraction in ContextParcel and tests

--- a/lib/export/markdown_resume_exporter.dart
+++ b/lib/export/markdown_resume_exporter.dart
@@ -29,6 +29,11 @@ class MarkdownResumeExporter implements ContextMemoryExporter {
       if (parcel.tags.isNotEmpty) {
         buffer.writeln('_Tags:_ ${parcel.tags.join(', ')}');
       }
+      if (parcel.inlineTags.isNotEmpty) {
+        buffer.writeln(
+          '_Inline Tags:_ ${parcel.inlineTags.map((e) => e.label).join(', ')}',
+        );
+      }
       buffer.writeln();
     }
     return buffer.toString().trim();

--- a/lib/export/routed_context_exporter.dart
+++ b/lib/export/routed_context_exporter.dart
@@ -16,7 +16,10 @@ class RoutedContextExporter {
   RoutedContextExporter({this.basePath = 'export/context'});
 
   /// Writes [result] groups to the filesystem.
-  Future<void> export(RoutingResult result, {bool includeUnassigned = false}) async {
+  Future<void> export(
+    RoutingResult result, {
+    bool includeUnassigned = false,
+  }) async {
     await _writeGroups(result.byFeature, 'by_feature');
     await _writeGroups(result.byModule, 'by_module');
     if (includeUnassigned) {
@@ -24,7 +27,10 @@ class RoutedContextExporter {
     }
   }
 
-  Future<void> _writeGroups(Map<String, List<ContextParcel>> groups, String subdir) async {
+  Future<void> _writeGroups(
+    Map<String, List<ContextParcel>> groups,
+    String subdir,
+  ) async {
     for (final entry in groups.entries) {
       if (entry.value.isEmpty) continue;
       final dirName = _sanitizeName(entry.key);
@@ -53,6 +59,12 @@ class RoutedContextExporter {
     if (parcel.tags.isNotEmpty) {
       buffer.writeln();
       buffer.writeln('_Tags:_ ${parcel.tags.join(', ')}');
+    }
+    if (parcel.inlineTags.isNotEmpty) {
+      buffer.writeln();
+      buffer.writeln(
+        '_Inline Tags:_ ${parcel.inlineTags.map((e) => e.label).join(', ')}',
+      );
     }
     return buffer.toString().trim();
   }

--- a/lib/models/context_tag.dart
+++ b/lib/models/context_tag.dart
@@ -50,6 +50,14 @@ enum ContextTag {
     return null;
   }
 
+  /// Returns the tag matching [label], or `null` if unrecognized.
+  static ContextTag? fromLabel(String label) {
+    for (final tag in ContextTag.values) {
+      if (tag.label == label) return tag;
+    }
+    return null;
+  }
+
   /// Returns `true` if [line] begins with a recognized context tag.
   static bool isValidTaggedLine(String line) => fromLine(line) != null;
 

--- a/test/models/context_parcel_inline_tags_test.dart
+++ b/test/models/context_parcel_inline_tags_test.dart
@@ -1,0 +1,33 @@
+import 'package:test/test.dart';
+
+import '../../lib/models/context_parcel.dart';
+import '../../lib/models/context_tag.dart';
+
+void main() {
+  group('ContextParcel inline tag extraction', () {
+    test('extracts tags from multiline summary', () {
+      final summary = '[BUG_FIX] Fixed A\nSome text\n[DECISION] Use B';
+      final parcel = ContextParcel(summary: summary, mergeHistory: []);
+      expect(parcel.inlineTags.contains(ContextTag.bugFix), isTrue);
+      expect(parcel.inlineTags.contains(ContextTag.decision), isTrue);
+      expect(parcel.inlineTags.length, 2);
+    });
+
+    test('deduplicates duplicate tags', () {
+      final summary = '[PLAN] Step1\n[PLAN] Step2';
+      final parcel = ContextParcel(summary: summary, mergeHistory: []);
+      expect(parcel.inlineTags, {ContextTag.plan});
+    });
+
+    test('returns empty set when no tags present', () {
+      final parcel = ContextParcel(summary: 'No tags here', mergeHistory: []);
+      expect(parcel.inlineTags, isEmpty);
+    });
+
+    test('ignores invalid tags', () {
+      final summary = '[UNKNOWN] Text\n[BUG_FIX] ok';
+      final parcel = ContextParcel(summary: summary, mergeHistory: []);
+      expect(parcel.inlineTags, {ContextTag.bugFix});
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- allow parsing inline role tags from ContextParcel summaries
- expose `ContextTag.fromLabel`
- include inline tags in JSON and Markdown exports
- update routed exporter to show inline tags
- add unit tests for tag extraction
- log entry for new feature

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_b_6882c3f7014883219d455f08fe1123c4