### PR TITLE
Update LLM instructions with tagging guidance

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -177,3 +177,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507242254][460636a][DOC] Documented routed context output format
 [2507242327][202dd0][FTR][DOC] Added ContextTag enum and tagging schema documentation
 [2507242348][b645f5c][FTR][TST] Added inline tag extraction in ContextParcel and tests
+[2507242353][a16cc19][FTR][DOC] Updated LLM instruction template with tagging guidance

--- a/docs/context_tagging_schema.md
+++ b/docs/context_tagging_schema.md
@@ -30,3 +30,16 @@ A line without a recognized tag is treated as regular summary text.
 [ARCH_NOTE] Parser layer separated from UI for testing.
 [PLAN] Implement caching next sprint.
 ```
+
+### Instruction Snippet
+
+The LLM summarization template encourages tagging inline:
+
+```text
+Analyze the prompt and response carefully and capture only high-value context.
+- Ignore filler text or social niceties.
+- Prioritize concrete facts, decisions, bug fixes, and architectural insights.
+- Preserve code snippets or key configuration details exactly as written.
+- Omit prompts or responses that add no new insight.
+- Use tags [DECISION], [BUG_FIX], [PLAN], [BLOCKER], [ARCH_NOTE] at the start of relevant lines when helpful.
+```

--- a/lib/src/instructions/llm_instruction_templates.dart
+++ b/lib/src/instructions/llm_instruction_templates.dart
@@ -10,6 +10,7 @@ Analyze the prompt and response carefully and capture only high-value context.
 - Prioritize concrete facts, decisions, bug fixes, and architectural insights.
 - Preserve code snippets or key configuration details exactly as written.
 - Omit prompts or responses that add no new insight.
+- Use tags [DECISION], [BUG_FIX], [PLAN], [BLOCKER], [ARCH_NOTE] at the start of relevant lines when helpful.
 ''';
 
 const String mergeInstruction = '''
@@ -19,6 +20,7 @@ When merging new context with existing summaries:
 - If contradictions arise, prefer the most recent statement unless earlier
   information is clearly more reliable.
 - Mark unresolved areas as unclear rather than discarding them.
+- Maintain role tags like [DECISION], [BUG_FIX], [PLAN], [BLOCKER], [ARCH_NOTE].
 ''';
 
 const String initialExchangePromptTemplate = '''


### PR DESCRIPTION
## Summary
- update `llm_instruction_templates.dart` to encourage inline tags
- add LLM instruction snippet example in `context_tagging_schema.md`

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6882c6daa3a8832188c2cffe61384fab