### PR TITLE
Implement tag indexing across final memory

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -178,3 +178,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507242327][202dd0][FTR][DOC] Added ContextTag enum and tagging schema documentation
 [2507242348][b645f5c][FTR][TST] Added inline tag extraction in ContextParcel and tests
 [2507242353][a16cc19][FTR][DOC] Updated LLM instruction template with tagging guidance
+[2507250006][3ceed87][FTR][TST] Added TagIndexer and tag index generation

--- a/lib/models/context_memory.dart
+++ b/lib/models/context_memory.dart
@@ -10,6 +10,9 @@ class ContextMemory {
   /// Ordered list of merged context parcels representing the conversation.
   final List<ContextParcel> parcels;
 
+  /// Map of inline tag labels to parcel indices.
+  final Map<String, List<int>> tagIndex;
+
   /// Timestamp when this memory snapshot was generated.
   final DateTime? generatedAt;
 
@@ -45,6 +48,7 @@ class ContextMemory {
 
   ContextMemory({
     List<ContextParcel>? parcels,
+    Map<String, List<int>>? tagIndex,
     this.generatedAt,
     this.sourceConversationId,
     this.exchangeCount,
@@ -53,13 +57,18 @@ class ContextMemory {
     this.confidence,
     this.completeness,
     this.limitations,
-  }) : parcels = parcels ?? [];
+  })  : parcels = parcels ?? [],
+        tagIndex = tagIndex ?? {};
 
   factory ContextMemory.fromJson(Map<String, dynamic> json) => ContextMemory(
         parcels: (json['parcels'] as List<dynamic>?)
                 ?.map((e) => ContextParcel.fromJson(e as Map<String, dynamic>))
                 .toList() ??
             [],
+        tagIndex: (json['tagIndex'] as Map<String, dynamic>?)?.map(
+              (k, v) => MapEntry(k, List<int>.from(v as List<dynamic>)),
+            ) ??
+            {},
         generatedAt: json['generatedAt'] != null
             ? DateTime.parse(json['generatedAt'])
             : null,
@@ -74,6 +83,7 @@ class ContextMemory {
 
   Map<String, dynamic> toJson() => {
         'parcels': parcels.map((e) => e.toJson()).toList(),
+        if (tagIndex.isNotEmpty) 'tagIndex': tagIndex,
         'generatedAt': generatedAt?.toIso8601String(),
         'sourceConversationId': sourceConversationId,
         'exchangeCount': exchangeCount,

--- a/lib/services/context_memory_builder.dart
+++ b/lib/services/context_memory_builder.dart
@@ -1,5 +1,6 @@
 import '../models/context_memory.dart';
 import '../models/context_parcel.dart';
+import 'tag_indexer.dart';
 
 /// Utility for constructing a finalized [ContextMemory] from the
 /// latest [ContextParcel] produced by the merge pipeline.
@@ -35,8 +36,11 @@ class ContextMemoryBuilder {
       }
     }
 
+    final indexer = TagIndexer.indexAllTags(parcels);
+
     return ContextMemory(
       parcels: parcels,
+      tagIndex: indexer.tagIndex,
       generatedAt: genAt,
       sourceConversationId: sourceConversationId,
       exchangeCount: exchangeCount,

--- a/lib/services/tag_indexer.dart
+++ b/lib/services/tag_indexer.dart
@@ -1,0 +1,58 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../models/context_parcel.dart';
+import '../models/context_tag.dart';
+
+/// Builds an index of inline tags across a list of [ContextParcel]s.
+class TagIndexer {
+  /// Maps tag labels to the list of parcel indices containing them.
+  final Map<String, List<int>> tagIndex = {};
+
+  TagIndexer();
+
+  /// Generates a [TagIndexer] for [parcels].
+  factory TagIndexer.indexAllTags(List<ContextParcel> parcels) {
+    final indexer = TagIndexer();
+    for (var i = 0; i < parcels.length; i++) {
+      final parcel = parcels[i];
+      for (final tag in parcel.inlineTags) {
+        indexer.tagIndex.putIfAbsent(tag.label, () => []).add(i);
+      }
+    }
+    return indexer;
+  }
+
+  /// Returns indices of parcels associated with [label].
+  List<int> getParcelsWithTag(String label) =>
+      List<int>.unmodifiable(tagIndex[label] ?? const []);
+
+  /// Saves the index to [filePath] as JSON.
+  void saveToFile(String filePath) {
+    final file = File(filePath);
+    final data = tagIndex;
+    file.writeAsStringSync(jsonEncode(data));
+  }
+
+  /// Loads a previously saved index from [filePath].
+  static TagIndexer loadFromFile(String filePath) {
+    final file = File(filePath);
+    if (!file.existsSync()) return TagIndexer();
+    try {
+      final data = jsonDecode(file.readAsStringSync());
+      if (data is Map<String, dynamic>) {
+        final indexer = TagIndexer();
+        data.forEach((key, value) {
+          if (!ContextTag.isValidTagName(key)) return;
+          if (value is List) {
+            indexer.tagIndex[key] = value.whereType<int>().toList();
+          }
+        });
+        return indexer;
+      }
+    } catch (_) {
+      // Ignore malformed cache
+    }
+    return TagIndexer();
+  }
+}

--- a/test/context_memory_test.dart
+++ b/test/context_memory_test.dart
@@ -53,6 +53,7 @@ void main() {
       expect(roundTrip.parcels.first.feature, 'search');
       expect(roundTrip.parcels.first.system, 'parser');
       expect(roundTrip.parcels.first.module, 'ContextRouter');
+      expect(roundTrip.tagIndex.isEmpty, isTrue);
     });
   });
 }

--- a/test/memory/context_memory_builder_test.dart
+++ b/test/memory/context_memory_builder_test.dart
@@ -48,6 +48,7 @@ void main() {
       expect(memory.completeness, 'complete');
       expect(memory.limitations, 'none');
       expect(memory.generatedAt, ts);
+      expect(memory.tagIndex.isEmpty, isTrue);
     });
 
     test('preserves manual edits in final memory', () {
@@ -65,6 +66,7 @@ void main() {
       final memory = ContextMemoryBuilder.buildFinalMemory(latest: latest);
       expect(memory.parcels.first.manualEdits.length, 1);
       expect(memory.parcels.first.manualEdits.first.exchangeId, 1);
+      expect(memory.tagIndex.isEmpty, isTrue);
     });
 
     test('infers generatedAt and exchangeCount', () {
@@ -73,6 +75,7 @@ void main() {
       expect(memory.parcels.length, 1);
       expect(memory.generatedAt, isNotNull);
       expect(memory.exchangeCount, 3);
+      expect(memory.tagIndex.isEmpty, isTrue);
     });
   });
 }

--- a/test/services/tag_indexer_test.dart
+++ b/test/services/tag_indexer_test.dart
@@ -1,0 +1,29 @@
+import 'package:test/test.dart';
+
+import '../../lib/models/context_parcel.dart';
+import '../../lib/services/tag_indexer.dart';
+
+void main() {
+  group('TagIndexer', () {
+    test('indexes parcels by inline tags', () {
+      final parcels = [
+        ContextParcel(summary: '[BUG_FIX] fix a', mergeHistory: [0]),
+        ContextParcel(summary: '[DECISION] use b\n[PLAN] step', mergeHistory: [1]),
+        ContextParcel(summary: 'no tag\n[ANSWER] done', mergeHistory: [2]),
+      ];
+      final indexer = TagIndexer.indexAllTags(parcels);
+      expect(indexer.tagIndex['BUG_FIX'], [0]);
+      expect(indexer.tagIndex['DECISION'], [1]);
+      expect(indexer.tagIndex['PLAN'], [1]);
+      expect(indexer.tagIndex['ANSWER'], [2]);
+    });
+
+    test('excludes invalid tags', () {
+      final parcels = [
+        ContextParcel(summary: '[UNKNOWN] text', mergeHistory: [0]),
+      ];
+      final indexer = TagIndexer.indexAllTags(parcels);
+      expect(indexer.tagIndex.isEmpty, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `TagIndexer` utility for building an inline tag index
- extend `ContextMemory` with `tagIndex` map
- generate tag index in `ContextMemoryBuilder`
- include tests for `TagIndexer` and update existing tests
- log new feature

## Testing
- `dart` executable missing – unable to run `dart test`

------
https://chatgpt.com/codex/tasks/task_b_6882c98a27fc8321b1b423a1c55d916d