### PR TITLE
Implement InjectableContext for LLM prompting

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -180,3 +180,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507242353][a16cc19][FTR][DOC] Updated LLM instruction template with tagging guidance
 [2507250006][3ceed87][FTR][TST] Added TagIndexer and tag index generation
 [2507250012][a8fcdac][TST] Added tag parser and export rendering tests
+[2507250021][e749e0b][FTR][TST] Added InjectableContext for prompt injection

--- a/lib/injection/injectable_context.dart
+++ b/lib/injection/injectable_context.dart
@@ -1,0 +1,77 @@
+import '../models/context_parcel.dart';
+
+/// Lightweight context snapshot optimized for prompt injection.
+class InjectableContext {
+  /// Concise summary text of the conversation segment.
+  final String summary;
+
+  /// Optional tags describing this context block.
+  final List<String> tags;
+
+  /// Optional role metadata (e.g. 'user', 'assistant').
+  final String? role;
+
+  /// When this context was generated.
+  final DateTime? timestamp;
+
+  /// Optional feature association for routing.
+  final String? feature;
+
+  /// Optional system or component name.
+  final String? system;
+
+  /// Optional module identifier.
+  final String? module;
+
+  InjectableContext({
+    required this.summary,
+    List<String>? tags,
+    this.role,
+    this.timestamp,
+    this.feature,
+    this.system,
+    this.module,
+  }) : tags = tags ?? [];
+
+  /// Builds an [InjectableContext] from a [ContextParcel].
+  factory InjectableContext.fromParcel(
+    ContextParcel parcel, {
+    String? role,
+    DateTime? timestamp,
+  }) => InjectableContext(
+    summary: parcel.summary,
+    tags: parcel.tags,
+    role: role,
+    timestamp: timestamp,
+    feature: parcel.feature,
+    system: parcel.system,
+    module: parcel.module,
+  );
+
+  /// Returns a compact string suitable for direct LLM injection.
+  String toInjectionString() {
+    final buffer = StringBuffer();
+    if (timestamp != null) {
+      buffer.write('${timestamp!.toIso8601String()} ');
+    }
+    if (role != null && role!.isNotEmpty) {
+      buffer.write('[$role] ');
+    }
+    buffer.write(summary.trim());
+    if (tags.isNotEmpty) {
+      buffer.write(' {${tags.join(', ')}}');
+    }
+    final meta = <String>[];
+    if (feature != null) meta.add('feature:$feature');
+    if (system != null) meta.add('system:$system');
+    if (module != null) meta.add('module:$module');
+    if (meta.isNotEmpty) {
+      buffer.write(' <${meta.join(', ')}>');
+    }
+    return buffer.toString().trim();
+  }
+
+  /// Concatenates multiple contexts into a single injection string.
+  static String concatenate(List<InjectableContext> entries) =>
+      entries.map((e) => e.toInjectionString()).join('\n');
+}

--- a/test/injection/injectable_context_test.dart
+++ b/test/injection/injectable_context_test.dart
@@ -1,0 +1,49 @@
+import 'package:test/test.dart';
+
+import '../../lib/injection/injectable_context.dart';
+import '../../lib/models/context_parcel.dart';
+
+void main() {
+  group('InjectableContext', () {
+    test('fromParcel copies basic fields', () {
+      final parcel = ContextParcel(
+        summary: 'Fixed bug',
+        mergeHistory: [0],
+        tags: ['bug'],
+        feature: 'search',
+        system: 'parser',
+        module: 'context',
+      );
+      final ctx = InjectableContext.fromParcel(
+        parcel,
+        role: 'assistant',
+        timestamp: DateTime.parse('2025-07-24T00:00:00Z'),
+      );
+      expect(ctx.summary, 'Fixed bug');
+      expect(ctx.tags, ['bug']);
+      expect(ctx.feature, 'search');
+      expect(ctx.system, 'parser');
+      expect(ctx.module, 'context');
+      expect(ctx.role, 'assistant');
+      expect(ctx.timestamp, DateTime.parse('2025-07-24T00:00:00Z'));
+    });
+
+    test('toInjectionString renders compact output', () {
+      final ctx = InjectableContext(
+        summary: 'Add search bar',
+        tags: ['ui', 'feature'],
+        role: 'user',
+        timestamp: DateTime.parse('2025-07-24T01:00:00Z'),
+      );
+      final str = ctx.toInjectionString();
+      expect(str, '2025-07-24T01:00:00Z [user] Add search bar {ui, feature}');
+    });
+
+    test('concatenate joins multiple entries', () {
+      final a = InjectableContext(summary: 'A');
+      final b = InjectableContext(summary: 'B');
+      final joined = InjectableContext.concatenate([a, b]);
+      expect(joined, 'A\nB');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `InjectableContext` for lightweight prompt-ready memory
- provide conversion from `ContextParcel`
- serialize to compact injection strings and join multiple entries
- test conversion, serialization, and concatenation
- log new feature

## Testing
- `dart pub get` *(fails: Flutter SDK not available)*
- `dart test` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_b_6882cd16b30c83219b653ae2610f76e2