### PR TITLE
Implement InjectionFormatter for multiple output styles

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -182,3 +182,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507250012][a8fcdac][TST] Added tag parser and export rendering tests
 [2507250021][e749e0b][FTR][TST] Added InjectableContext for prompt injection
 [2507250029][17ce72][FTR][TST] Implemented MemorySlicer with filtering and tests
+[2507250107][989d762][FTR][TST] Added InjectionFormatter with multi-format output

--- a/lib/injection/injection_formatter.dart
+++ b/lib/injection/injection_formatter.dart
@@ -1,0 +1,60 @@
+import 'dart:convert';
+
+import 'injectable_context.dart';
+
+/// Utility to convert [InjectableContext] entries into various
+/// injection-ready text formats.
+class InjectionFormatter {
+  /// Context entries to format.
+  final List<InjectableContext> entries;
+
+  /// Creates a formatter for [entries].
+  InjectionFormatter(this.entries);
+
+  /// Renders context using the ChatGPT-friendly format.
+  ///
+  /// Each entry becomes a line like:
+  /// `[TAG] Summary text`
+  String toChatFormat() =>
+      entries.map((e) => _chatLine(e)).join('\n');
+
+  String _chatLine(InjectableContext e) {
+    final tags = e.tags.map((t) => '[${t.trim()}]').join(' ');
+    final prefix = tags.isNotEmpty ? '$tags ' : '';
+    return '$prefix${e.summary.trim()}';
+  }
+
+  /// Renders context in a compact comment style for Codex planning.
+  ///
+  /// Example: `// PLAN: Do the thing`
+  String toCodexFormat() =>
+      entries.map((e) => _codexLine(e)).join('\n');
+
+  String _codexLine(InjectableContext e) {
+    final tag = e.tags.isNotEmpty ? e.tags.first : 'NOTE';
+    return '// $tag: ${e.summary.trim()}';
+  }
+
+  /// Renders context as JSON for external analyzers.
+  ///
+  /// Returns a JSON object if a single entry is provided or
+  /// a JSON array for multiple entries.
+  String toJsonSummary() {
+    if (entries.length == 1) {
+      return jsonEncode(_toMap(entries.first));
+    }
+    return jsonEncode(entries.map(_toMap).toList());
+  }
+
+  Map<String, dynamic> _toMap(InjectableContext e) {
+    return {
+      'tag': e.tags.isNotEmpty ? e.tags.first : null,
+      'summary': e.summary.trim(),
+      if (e.timestamp != null) 'timestamp': e.timestamp!.toIso8601String(),
+      if (e.role != null) 'role': e.role,
+      if (e.feature != null) 'feature': e.feature,
+      if (e.system != null) 'system': e.system,
+      if (e.module != null) 'module': e.module,
+    }..removeWhere((key, value) => value == null);
+  }
+}

--- a/test/injection/injection_formatter_test.dart
+++ b/test/injection/injection_formatter_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:test/test.dart';
+
+import '../../lib/injection/injection_formatter.dart';
+import '../../lib/injection/injectable_context.dart';
+
+void main() {
+  group('InjectionFormatter', () {
+    test('formats single entry for ChatGPT', () {
+      final ctx = InjectableContext(
+        summary: 'Route context by feature',
+        tags: ['DECISION'],
+      );
+      final formatter = InjectionFormatter([ctx]);
+      expect(formatter.toChatFormat(), '[DECISION] Route context by feature');
+    });
+
+    test('formats multiple entries for ChatGPT', () {
+      final entries = [
+        InjectableContext(summary: 'Do A', tags: ['PLAN']),
+        InjectableContext(summary: 'Do B', tags: ['PLAN']),
+      ];
+      final formatter = InjectionFormatter(entries);
+      expect(
+        formatter.toChatFormat(),
+        '[PLAN] Do A\n[PLAN] Do B',
+      );
+    });
+
+    test('formats single entry for Codex', () {
+      final ctx = InjectableContext(
+        summary: 'Extract routing',
+        tags: ['PLAN'],
+      );
+      final formatter = InjectionFormatter([ctx]);
+      expect(formatter.toCodexFormat(), '// PLAN: Extract routing');
+    });
+
+    test('formats multiple entries for Codex', () {
+      final entries = [
+        InjectableContext(summary: 'Note one', tags: ['ARCH_NOTE']),
+        InjectableContext(summary: 'Note two'),
+      ];
+      final formatter = InjectionFormatter(entries);
+      expect(
+        formatter.toCodexFormat(),
+        '// ARCH_NOTE: Note one\n// NOTE: Note two',
+      );
+    });
+
+    test('formats single entry as JSON', () {
+      final ts = DateTime.parse('2025-07-25T12:45:00Z');
+      final ctx = InjectableContext(
+        summary: 'Fix bug',
+        tags: ['BUG_FIX'],
+        timestamp: ts,
+      );
+      final formatter = InjectionFormatter([ctx]);
+      final json = jsonDecode(formatter.toJsonSummary()) as Map<String, dynamic>;
+      expect(json['tag'], 'BUG_FIX');
+      expect(json['summary'], 'Fix bug');
+      expect(json['timestamp'], ts.toIso8601String());
+    });
+
+    test('formats multiple entries as JSON array', () {
+      final entries = [
+        InjectableContext(summary: 'A'),
+        InjectableContext(summary: 'B'),
+      ];
+      final formatter = InjectionFormatter(entries);
+      final json = jsonDecode(formatter.toJsonSummary()) as List<dynamic>;
+      expect(json.length, 2);
+      expect(json[0]['summary'], 'A');
+      expect(json[1]['summary'], 'B');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `InjectionFormatter` to render `InjectableContext` entries
- support ChatGPT, Codex, and JSON formats
- unit tests for new formatter
- log new feature

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6882d7ccebdc8321a11286b7c762cb85