### PR TITLE
Implement MemorySelector for context export

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -183,3 +183,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507250021][e749e0b][FTR][TST] Added InjectableContext for prompt injection
 [2507250029][17ce72][FTR][TST] Implemented MemorySlicer with filtering and tests
 [2507250107][989d762][FTR][TST] Added InjectionFormatter with multi-format output
+[2507250339][4555598][FTR][TST] Added MemorySelector with filtering and interactive selection tests

--- a/lib/services/memory_selector.dart
+++ b/lib/services/memory_selector.dart
@@ -1,0 +1,82 @@
+import 'dart:io';
+
+import '../models/context_memory.dart';
+import '../models/context_parcel.dart';
+import '../injection/injectable_context.dart';
+import 'memory_slicer.dart';
+
+/// Provides selection and preview of ContextParcels for export or injection.
+class MemorySelector {
+  final List<ContextParcel> _parcels;
+
+  MemorySelector(List<ContextParcel> parcels)
+      : _parcels = List<ContextParcel>.from(parcels);
+
+  /// Creates a selector from a [ContextMemory].
+  factory MemorySelector.fromMemory(ContextMemory memory) =>
+      MemorySelector(memory.parcels);
+
+  /// Returns parcels containing [tag].
+  List<ContextParcel> selectByTag(String tag) =>
+      MemorySlicer(_parcels).sliceByTag(tag);
+
+  /// Returns parcels whose summary contains [keyword].
+  List<ContextParcel> selectByKeyword(String keyword) =>
+      MemorySlicer(_parcels).sliceByTopic(keyword);
+
+  /// Returns the most recent [count] parcels.
+  List<ContextParcel> selectRecent(int count) =>
+      MemorySlicer(_parcels).sliceRecent(count);
+
+  /// Returns the [custom] list as-is for manual selection convenience.
+  List<ContextParcel> selectCustom(List<ContextParcel> custom) =>
+      List<ContextParcel>.from(custom);
+
+  /// Renders a simple numbered preview of [parcels] to [out].
+  void preview(List<ContextParcel> parcels, {StringSink? out}) {
+    final sink = out ?? stdout;
+    if (parcels.isEmpty) {
+      sink.writeln('(no entries)');
+      return;
+    }
+    for (var i = 0; i < parcels.length; i++) {
+      final p = parcels[i];
+      final tags = <String>[
+        ...p.inlineTags.map((e) => '[${e.label}]'),
+        ...p.tags.map((e) => '[${e}]'),
+      ];
+      final tagStr = tags.isNotEmpty ? '${tags.join(' ')} ' : '';
+      sink.writeln('${i + 1}. $tagStr${p.summary.trim()}');
+    }
+  }
+
+  /// Prompts the user to choose entries from [parcels].
+  /// Returns the selected list or empty if none chosen.
+  Future<List<ContextParcel>> interactiveSelect(
+    List<ContextParcel> parcels, {
+    String? Function()? readInput,
+    StringSink? out,
+  }) async {
+    final sink = out ?? stdout;
+    final read = readInput ?? stdin.readLineSync;
+    if (parcels.isEmpty) {
+      sink.writeln('MemorySelector: no entries to select.');
+      return [];
+    }
+    preview(parcels, out: sink);
+    sink.write('Enter indices separated by commas: ');
+    final line = read()?.trim();
+    if (line == null || line.isEmpty) return [];
+    final indices = line
+        .split(',')
+        .map((e) => int.tryParse(e.trim()))
+        .where((i) => i != null && i! > 0 && i! <= parcels.length)
+        .map((i) => i! - 1)
+        .toSet();
+    return indices.map((i) => parcels[i]).toList();
+  }
+
+  /// Converts [parcels] to [InjectableContext] entries.
+  List<InjectableContext> toInjectable(List<ContextParcel> parcels, {String? role}) =>
+      parcels.map((p) => InjectableContext.fromParcel(p, role: role)).toList();
+}

--- a/test/services/memory_selector_test.dart
+++ b/test/services/memory_selector_test.dart
@@ -1,0 +1,60 @@
+import 'package:test/test.dart';
+
+import '../../lib/models/context_parcel.dart';
+import '../../lib/models/context_memory.dart';
+import '../../lib/services/memory_selector.dart';
+
+void main() {
+  group('MemorySelector', () {
+    final parcels = [
+      ContextParcel(summary: '[PLAN] add ui', mergeHistory: [0]),
+      ContextParcel(summary: '[BUG_FIX] fix crash', mergeHistory: [1], tags: ['bug']),
+      ContextParcel(summary: 'Discuss search bar', mergeHistory: [2], tags: ['feature']),
+    ];
+    final memory = ContextMemory(parcels: parcels);
+
+    test('selectByTag finds tags or inline tags', () {
+      final selector = MemorySelector.fromMemory(memory);
+      final plan = selector.selectByTag('PLAN');
+      expect(plan.length, 1);
+      expect(plan.first.summary, contains('add ui'));
+    });
+
+    test('selectByKeyword matches topic', () {
+      final selector = MemorySelector.fromMemory(memory);
+      final search = selector.selectByKeyword('search');
+      expect(search.length, 1);
+      expect(search.first.summary, contains('search bar'));
+    });
+
+    test('selectRecent returns last N', () {
+      final selector = MemorySelector.fromMemory(memory);
+      final last = selector.selectRecent(2);
+      expect(last.length, 2);
+      expect(last.first.summary, contains('fix crash'));
+    });
+
+    test('selectCustom echoes provided list', () {
+      final selector = MemorySelector.fromMemory(memory);
+      final custom = selector.selectCustom([parcels[0], parcels[2]]);
+      expect(custom.length, 2);
+      expect(custom.first.summary, contains('add ui'));
+    });
+
+    test('preview handles empty lists', () {
+      final selector = MemorySelector.fromMemory(memory);
+      final buffer = StringBuffer();
+      selector.preview([], out: buffer);
+      expect(buffer.toString().trim(), '(no entries)');
+    });
+
+    test('interactiveSelect parses indices', () async {
+      final selector = MemorySelector.fromMemory(memory);
+      final buffer = StringBuffer();
+      final result = await selector.interactiveSelect(parcels,
+          readInput: () => '1,3', out: buffer);
+      expect(result.length, 2);
+      expect(result.first.summary, contains('add ui'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `MemorySelector` service for filtering and manual selection of memory
- provide unit tests covering filter methods and CLI selection
- log feature in CODEXLOG

## Testing
- ❌ `dart format lib/services/memory_selector.dart test/services/memory_selector_test.dart` (dart not installed)
- ❌ `dart test` (dart not installed)

------
https://chatgpt.com/codex/tasks/task_b_6882fb8144308321906a2817cd66eb01