### PR TITLE
Add injection output examples

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -184,3 +184,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507250029][17ce72][FTR][TST] Implemented MemorySlicer with filtering and tests
 [2507250107][989d762][FTR][TST] Added InjectionFormatter with multi-format output
 [2507250339][4555598][FTR][TST] Added MemorySelector with filtering and interactive selection tests
+[2507250348][ec08ac][DOC] Added injection output documentation examples

--- a/docs/injection_examples.json
+++ b/docs/injection_examples.json
@@ -1,0 +1,12 @@
+[
+  {
+    "tag": "DECISION",
+    "summary": "Chose to route context by feature",
+    "timestamp": "2025-07-25T09:30:00Z"
+  },
+  {
+    "tag": "BUG_FIX",
+    "summary": "Resolved conflict in module export paths",
+    "timestamp": "2025-07-25T09:50:00Z"
+  }
+]

--- a/docs/injection_examples.md
+++ b/docs/injection_examples.md
@@ -1,0 +1,37 @@
+# Injection Output Examples
+
+This document demonstrates how `InjectableContext` entries can be rendered for different injection targets.
+
+## ChatGPT Prompt Style
+Use when pasting context directly into a ChatGPT session. Each line begins with inline tags followed by the summary.
+
+```
+2025-07-25T09:30:00Z [DECISION] Chose to route context by feature
+2025-07-25T09:50:00Z [BUG_FIX] Resolved conflict in module export paths
+```
+
+## Codex Task-Planning Format
+Structured comment blocks suitable for Codex planning prompts.
+
+```
+// DECISION: Chose to route context by feature (2025-07-25T09:30:00Z)
+// BUG_FIX: Resolved conflict in module export paths (2025-07-25T09:50:00Z)
+```
+
+## External Summarizer JSON
+Compact JSON for downstream analyzers or summarizers.
+
+```json
+[
+  {
+    "tag": "DECISION",
+    "summary": "Chose to route context by feature",
+    "timestamp": "2025-07-25T09:30:00Z"
+  },
+  {
+    "tag": "BUG_FIX",
+    "summary": "Resolved conflict in module export paths",
+    "timestamp": "2025-07-25T09:50:00Z"
+  }
+]
+```


### PR DESCRIPTION
## Summary
- document how to render `InjectableContext` for various targets
- show example output for ChatGPT, Codex comments, and JSON summarizers
- provide sample JSON file of the same entries
- record new log entry

## Testing
- `dart test` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6882fdba1a94832194c9dfffdc4503cb