### PR TITLE
Implement OpenAI LLM client

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -185,3 +185,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507250107][989d762][FTR][TST] Added InjectionFormatter with multi-format output
 [2507250339][4555598][FTR][TST] Added MemorySelector with filtering and interactive selection tests
 [2507250348][ec08ac][DOC] Added injection output documentation examples
+[2507252307][1a981c0][FTR][CFG] Implemented OpenAI client and added http dependency

--- a/lib/services/llm_client.dart
+++ b/lib/services/llm_client.dart
@@ -1,3 +1,8 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+
 typedef PromptSender = Future<String> Function(String);
 
 class LLMClient {
@@ -5,7 +10,40 @@ class LLMClient {
   static PromptSender sendPrompt = _defaultSendPrompt;
 
   static Future<String> _defaultSendPrompt(String prompt) async {
-    // TODO: Connect to real LLM
-    return '';
+    final apiKey = Platform.environment['OPENAI_API_KEY_COLOG'];
+    if (apiKey == null || apiKey.isEmpty) {
+      throw Exception('OPENAI_API_KEY_COLOG not found in environment.');
+    }
+
+    final response = await http.post(
+      Uri.parse('https://api.openai.com/v1/chat/completions'),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $apiKey',
+      },
+      body: jsonEncode({
+        'model': 'gpt-3.5-turbo',
+        'messages': [
+          {'role': 'user', 'content': prompt}
+        ],
+        'temperature': 0.2,
+      }),
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception(
+          'OpenAI request failed: ${response.statusCode} ${response.body}');
+    }
+
+    final Map<String, dynamic> json = jsonDecode(response.body);
+    final choices = json['choices'];
+    if (choices is List && choices.isNotEmpty) {
+      final message = choices[0]['message'];
+      if (message is Map<String, dynamic> && message['content'] != null) {
+        return message['content'] as String;
+      }
+    }
+
+    throw Exception('OpenAI response missing message content');
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   shared_preferences: ^2.2.2
   intl: ^0.18.1
   args: ^2.4.2
+  http: ^1.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- connect `LLMClient` to OpenAI's chat completion API
- add `http` package for network calls
- log the new feature implementation

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68840d7b88b48321b5718a0f90c637e7