### PR TITLE
Fix LLM JSON parsing and instructions

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -189,3 +189,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507252316][5671e43][FTR][LLM] Switched SingleExchangeProcessor to parse OpenAI response via LLMClient
 [2507252356][e77383][SNC][DOC] Added LLM summarization UI entrypoint task
 [2507260010][c5e3a8][FTR][UI] Added LLM summarization menu and inline summary rendering
+[2507260035][e2210f4][BUG][LLM] Hardened LLM JSON parsing and enforced JSON-only responses

--- a/lib/debug/debug_logger.dart
+++ b/lib/debug/debug_logger.dart
@@ -127,15 +127,20 @@ $rawResponse
   }
 
   /// Logs an error message with optional [error] and [stack] details.
-  static void logError(String message, {Object? error, StackTrace? stack}) {
+  static void logError(String message,
+      {Object? error, StackTrace? stack, String? raw}) {
     if (!AppConfig.debugMode) return;
     final timestamp = DateTime.now().toIso8601String();
     final entry = '[$timestamp] ERROR: $message';
     print(entry);
     if (error != null) print(error);
+    if (raw != null) print('RAW CONTENT: $raw');
     if (stack != null) print(stack);
     final file = File('debug/errors.log');
-    file.writeAsStringSync('$entry\n', mode: FileMode.append);
+    final buffer = StringBuffer(entry);
+    if (error != null) buffer.write(' | $error');
+    if (raw != null) buffer.write(' | RAW: $raw');
+    file.writeAsStringSync('${buffer.toString()}\n', mode: FileMode.append);
   }
 
   /// Logs the parsed [parcel] returned from the LLM.

--- a/lib/memory/single_exchange_processor.dart
+++ b/lib/memory/single_exchange_processor.dart
@@ -65,9 +65,16 @@ $responseText''';
       throw MergeException('LLM response content is empty');
     }
 
+    Map<String, dynamic> parsed;
     try {
-      final Map<String, dynamic> json = jsonDecode(content);
-      final newParcel = ContextParcel.fromJson(json);
+      parsed = jsonDecode(content);
+    } catch (e) {
+      DebugLogger.logError('LLM returned non-JSON content', error: e, stack: StackTrace.current, raw: content);
+      throw MergeException('Invalid JSON format in LLM response');
+    }
+
+    try {
+      final newParcel = ContextParcel.fromJson(parsed);
 
       if (newParcel.summary.isEmpty && newParcel.mergeHistory.isEmpty) {
         throw const FormatException();
@@ -80,7 +87,7 @@ $responseText''';
 
       return newParcel;
     } catch (e, stack) {
-      DebugLogger.logError('LLM merge failed', error: e, stack: stack);
+      DebugLogger.logError('LLM merge failed', error: e, stack: stack, raw: content);
       throw MergeException('LLM returned invalid ContextParcel format');
     }
   }

--- a/lib/src/instructions/llm_instruction_templates.dart
+++ b/lib/src/instructions/llm_instruction_templates.dart
@@ -11,6 +11,7 @@ Analyze the prompt and response carefully and capture only high-value context.
 - Preserve code snippets or key configuration details exactly as written.
 - Omit prompts or responses that add no new insight.
 - Use tags [DECISION], [BUG_FIX], [PLAN], [BLOCKER], [ARCH_NOTE] at the start of relevant lines when helpful.
+Respond only with a strict JSON object and nothing else. Do not include explanations or Markdown formatting.
 ''';
 
 const String mergeInstruction = '''
@@ -21,6 +22,7 @@ When merging new context with existing summaries:
   information is clearly more reliable.
 - Mark unresolved areas as unclear rather than discarding them.
 - Maintain role tags like [DECISION], [BUG_FIX], [PLAN], [BLOCKER], [ARCH_NOTE].
+Respond only with a strict JSON object and nothing else. Do not include explanations or Markdown formatting.
 ''';
 
 const String initialExchangePromptTemplate = '''
@@ -30,6 +32,7 @@ RESPONSE: {{response}}
 
 Extract high-value context suitable for persistent project memory. Use the instruction set:
 $singleExchangeInstruction
+Respond only with a strict JSON object and nothing else. Do not include explanations or Markdown formatting.
 ''';
 
 const String subsequentExchangePromptTemplate = '''
@@ -42,6 +45,7 @@ RESPONSE: {{response}}
 
 Apply the following merge instructions to update the context:
 $mergeInstruction
+Respond only with a strict JSON object and nothing else. Do not include explanations or Markdown formatting.
 ''';
 
 String examplePrompt(bool isFirst) {


### PR DESCRIPTION
## Summary
- enforce JSON-only answers in LLM instruction templates
- log raw LLM errors and handle invalid JSON gracefully
- track hardened parsing in log

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6884221ed2ac8321acde4f176de4bc69