### PR TITLE
Add debug logs for LLM summary flow

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -191,3 +191,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507260010][c5e3a8][FTR][UI] Added LLM summarization menu and inline summary rendering
 [2507260035][e2210f4][BUG][LLM] Hardened LLM JSON parsing and enforced JSON-only responses
 [2507260042][550560][BUG][UI] Fixed summary parsing log and render
+[2507260054][a3492c][BUG][FTR] Added debug logs for LLM summary flow

--- a/lib/memory/single_exchange_processor.dart
+++ b/lib/memory/single_exchange_processor.dart
@@ -74,19 +74,19 @@ $responseText''';
     }
 
     try {
-      final newParcel = ContextParcel.fromJson(parsed);
-      DebugLogger.log('Parsed ContextParcel summary: ${newParcel.summary}');
+      final contextParcel = ContextParcel.fromJson(parsed);
+      DebugLogger.log('LLM Summary Returned: ${contextParcel.summary}');
 
-      if (newParcel.summary.isEmpty && newParcel.mergeHistory.isEmpty) {
+      if (contextParcel.summary.isEmpty && contextParcel.mergeHistory.isEmpty) {
         throw const FormatException();
       }
 
       if (AppConfig.debugMode) {
         DebugLogger.logRawResponse(jsonEncode(response));
-        DebugLogger.logParsedParcel(newParcel);
+        DebugLogger.logParsedParcel(contextParcel);
       }
 
-      return newParcel;
+      return contextParcel;
     } catch (e, stack) {
       DebugLogger.logError('LLM merge failed', error: e, stack: stack, raw: content);
       throw MergeException('LLM returned invalid ContextParcel format');

--- a/lib/models/context_parcel.dart
+++ b/lib/models/context_parcel.dart
@@ -47,6 +47,7 @@ class ContextParcel {
 
   factory ContextParcel.fromJson(Map<String, dynamic> json) {
     final summary = json['summary'] as String? ?? '';
+    print('[DEBUG] ContextParcel.fromJson: summary = "$summary"');
     Set<ContextTag>? inline;
     if (json['inlineTags'] is List) {
       inline = <ContextTag>{};

--- a/lib/widgets/conversation_panel.dart
+++ b/lib/widgets/conversation_panel.dart
@@ -353,6 +353,7 @@ class _ExchangeTileState extends State<_ExchangeTile>
       }
       final Map<String, dynamic> json = jsonDecode(content);
       final parcel = ContextParcel.fromJson(json);
+      print('[DEBUG] Assigning llmSummary: "${parcel.summary}"');
       setState(() {
         widget.exchange.llmSummary = parcel.summary;
         _loading = false;
@@ -391,33 +392,39 @@ class _ExchangeTileState extends State<_ExchangeTile>
           )
         else if (widget.exchange.llmSummary != null &&
             widget.exchange.llmSummary!.trim().isNotEmpty)
-          Padding(
-            padding: const EdgeInsets.only(top: 4),
-            child: Card(
-              color: Colors.black54,
-              child: Padding(
-                padding: const EdgeInsets.all(8),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Expanded(
-                      child: Text(
-                        widget.exchange.llmSummary!,
-                        style: _ConversationPanelState.textStyle,
-                      ),
+          Builder(
+            builder: (context) {
+              print('[DEBUG] Rendering summary block for Exchange index: '
+                  '${widget.index}');
+              return Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Card(
+                  color: Colors.black54,
+                  child: Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(
+                          child: Text(
+                            widget.exchange.llmSummary!,
+                            style: _ConversationPanelState.textStyle,
+                          ),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.close, size: 16),
+                          padding: EdgeInsets.zero,
+                          visualDensity: VisualDensity.compact,
+                          onPressed: () {
+                            setState(() => widget.exchange.llmSummary = null);
+                          },
+                        )
+                      ],
                     ),
-                    IconButton(
-                      icon: const Icon(Icons.close, size: 16),
-                      padding: EdgeInsets.zero,
-                      visualDensity: VisualDensity.compact,
-                      onPressed: () {
-                        setState(() => widget.exchange.llmSummary = null);
-                      },
-                    )
-                  ],
+                  ),
                 ),
-              ),
-            ),
+              );
+            },
           ),
       ],
     );


### PR DESCRIPTION
## Summary
- log summary returned in `SingleExchangeProcessor`
- show summary value when deserializing `ContextParcel`
- log when assigning summary to an exchange
- note when a summary block is rendered
- record activity in `CODEXLOG_CURRENT.md`

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_6884268f079c83218d3a0526255681b7