### PR TITLE
Add raw LLM response debug output

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -192,3 +192,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507260035][e2210f4][BUG][LLM] Hardened LLM JSON parsing and enforced JSON-only responses
 [2507260042][550560][BUG][UI] Fixed summary parsing log and render
 [2507260054][a3492c][BUG][FTR] Added debug logs for LLM summary flow
+[2507260241][3dfb95][BUG][LLM] Printed raw LLM content before JSON parse

--- a/lib/memory/single_exchange_processor.dart
+++ b/lib/memory/single_exchange_processor.dart
@@ -65,6 +65,8 @@ $responseText''';
       throw MergeException('LLM response content is empty');
     }
 
+    print('[DEBUG] Raw LLM response content:\n$content');
+
     Map<String, dynamic> parsed;
     try {
       parsed = jsonDecode(content);


### PR DESCRIPTION
## Summary
- print raw LLM content before JSON parsing
- log new debug entry

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68843fd5a23c83218400723b85f2886e