### PR TITLE
Add debug print of full LLM response

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -193,3 +193,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507260042][550560][BUG][UI] Fixed summary parsing log and render
 [2507260054][a3492c][BUG][FTR] Added debug logs for LLM summary flow
 [2507260241][3dfb95][BUG][LLM] Printed raw LLM content before JSON parse
+[2507260327][c4b1a3a][BUG][LLM] Logged full OpenAI JSON response

--- a/lib/memory/single_exchange_processor.dart
+++ b/lib/memory/single_exchange_processor.dart
@@ -55,6 +55,11 @@ $responseText''';
     }
 
     final Map<String, dynamic> response = await LLMClient.sendPrompt(prompt);
+    if (AppConfig.debugMode) {
+      DebugLogger.logLLMCallRaw(
+          prompt: prompt, rawResponse: jsonEncode(response));
+      print('[DEBUG] Full OpenAI JSON response:\n$response');
+    }
     final choices = response['choices'];
     if (choices == null || choices.isEmpty) {
       throw MergeException('No choices returned from LLM');


### PR DESCRIPTION
## Summary
- log the entire JSON response from OpenAI when processing an exchange
- update development log

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68844adde39883219e6779eedf9b45fc