### PR TITLE
Improve LLM summarization prompts and logging

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -195,3 +195,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507260241][3dfb95][BUG][LLM] Printed raw LLM content before JSON parse
 [2507260327][c4b1a3a][BUG][LLM] Logged full OpenAI JSON response
 [2507260511][31df89f][DBG][LLM] Added step-by-step debug prints in SingleExchangeProcessor
+[2507260832][8e6e34][BUG][LLM] Enforced JSON-only summary with improved logs

--- a/lib/memory/single_exchange_processor.dart
+++ b/lib/memory/single_exchange_processor.dart
@@ -47,7 +47,7 @@ RESPONSE:
 $responseText''';
 
       if (AppConfig.debugMode) {
-        print('SingleExchangeProcessor prompt:\n$prompt');
+        print('[DEBUG] Prompt sent to LLM:\n$prompt');
         DebugLogger.logLLMCall(
           instructions: mergeInstructions,
           exchange: exchange,
@@ -59,7 +59,7 @@ $responseText''';
       if (AppConfig.debugMode) {
         DebugLogger.logLLMCallRaw(
             prompt: prompt, rawResponse: jsonEncode(response));
-        print('[DEBUG] LLM JSON received: $response');
+        print('[DEBUG] Full raw LLM response:\n${jsonEncode(response)}');
       }
       final choices = response['choices'];
       if (choices == null || choices.isEmpty) {
@@ -74,9 +74,7 @@ $responseText''';
         print('[DEBUG] Raw content string: $content');
       }
       if (content == null || content.trim().isEmpty) {
-        if (AppConfig.debugMode) {
-          print('[DEBUG] content was null or empty');
-        }
+        print('[DEBUG] content was null or empty');
         throw MergeException('LLM response content is empty');
       }
 
@@ -85,6 +83,9 @@ $responseText''';
         parsed = jsonDecode(content);
         if (AppConfig.debugMode) {
           print('[DEBUG] Parsed JSON: $parsed');
+        }
+        if (!parsed.containsKey('summary')) {
+          print('[DEBUG] Parsed JSON missing "summary" key');
         }
       } catch (e) {
         if (AppConfig.debugMode) {

--- a/lib/src/instructions/instruction_templates.dart
+++ b/lib/src/instructions/instruction_templates.dart
@@ -25,7 +25,9 @@ Summarize the intent, any problems discussed, solutions proposed, decisions made
 
 Omit conversational fluff, pleasantries, or reiteration of the full exchange.
 
-Respond ONLY with a valid JSON object. Example:
+Return only a valid JSON object in the form: { "summary": "..." }
+Do not include any explanation or commentary outside the JSON object.
+Example:
 {
   "summary": "User proposed adding a hover menu option to trigger LLM summarization. Assistant agreed and outlined required changes.",
   "tags": ["feature", "LLM integration", "UI"]
@@ -41,8 +43,8 @@ Your task is to merge the new exchange into the context memory.
 Update or append to the summary as needed.
 Preserve any prior important information unless it is clearly superseded or contradicted.
 
-Respond ONLY with a valid JSON object representing the updated memory.
-
+Return only a valid JSON object in the form: { "summary": "..." }
+Do not include any explanation or commentary outside the JSON object.
 Example:
 {
   "summary": "Initial CLI added. Later refined to support filters. Now extended with LLM summarization trigger.",
@@ -55,8 +57,8 @@ Example:
 You will be given a single user <-> assistant exchange.
 Build the initial context memory by summarizing what occurred and tagging it.
 
-Respond ONLY with a JSON object.
-
+Return only a valid JSON object in the form: { "summary": "..." }
+Do not include any explanation or commentary outside the JSON object.
 Example:
 {
   "summary": "User wants to structure their AI coding logs using ContextParcels. Assistant outlined file and model structure.",
@@ -68,7 +70,9 @@ Example:
 You will be given a complete context memory JSON object representing merged conversation history.
 Provide a concise snapshot capturing key features, decisions, and unresolved issues.
 
-Respond ONLY with a JSON object. Example:
+Return only a valid JSON object in the form: { "summary": "..." }
+Do not include any explanation or commentary outside the JSON object.
+Example:
 {
   "summary": "Memory includes CLI batch mode, manual review, and debug logging. UI integration remains in progress.",
   "tags": ["CLI", "manual review", "debug", "UI"]

--- a/lib/src/instructions/llm_instruction_templates.dart
+++ b/lib/src/instructions/llm_instruction_templates.dart
@@ -11,7 +11,8 @@ Analyze the prompt and response carefully and capture only high-value context.
 - Preserve code snippets or key configuration details exactly as written.
 - Omit prompts or responses that add no new insight.
 - Use tags [DECISION], [BUG_FIX], [PLAN], [BLOCKER], [ARCH_NOTE] at the start of relevant lines when helpful.
-Respond only with a strict JSON object and nothing else. Do not include explanations or Markdown formatting.
+Return only a valid JSON object in the form: { "summary": "..." }
+Do not include any explanation or commentary outside the JSON object.
 ''';
 
 const String mergeInstruction = '''
@@ -22,7 +23,8 @@ When merging new context with existing summaries:
   information is clearly more reliable.
 - Mark unresolved areas as unclear rather than discarding them.
 - Maintain role tags like [DECISION], [BUG_FIX], [PLAN], [BLOCKER], [ARCH_NOTE].
-Respond only with a strict JSON object and nothing else. Do not include explanations or Markdown formatting.
+Return only a valid JSON object in the form: { "summary": "..." }
+Do not include any explanation or commentary outside the JSON object.
 ''';
 
 const String initialExchangePromptTemplate = '''
@@ -32,7 +34,8 @@ RESPONSE: {{response}}
 
 Extract high-value context suitable for persistent project memory. Use the instruction set:
 $singleExchangeInstruction
-Respond only with a strict JSON object and nothing else. Do not include explanations or Markdown formatting.
+Return only a valid JSON object in the form: { "summary": "..." }
+Do not include any explanation or commentary outside the JSON object.
 ''';
 
 const String subsequentExchangePromptTemplate = '''
@@ -45,7 +48,8 @@ RESPONSE: {{response}}
 
 Apply the following merge instructions to update the context:
 $mergeInstruction
-Respond only with a strict JSON object and nothing else. Do not include explanations or Markdown formatting.
+Return only a valid JSON object in the form: { "summary": "..." }
+Do not include any explanation or commentary outside the JSON object.
 ''';
 
 String examplePrompt(bool isFirst) {

--- a/lib/widgets/conversation_panel.dart
+++ b/lib/widgets/conversation_panel.dart
@@ -354,8 +354,12 @@ class _ExchangeTileState extends State<_ExchangeTile>
       final Map<String, dynamic> json = jsonDecode(content);
       final parcel = ContextParcel.fromJson(json);
       print('[DEBUG] Assigning llmSummary: "${parcel.summary}"');
+      var summary = parcel.summary.trim();
+      if (summary.isEmpty) {
+        summary = '⚠️ No summary was generated.';
+      }
       setState(() {
-        widget.exchange.llmSummary = parcel.summary;
+        widget.exchange.llmSummary = summary;
         _loading = false;
       });
     } catch (e) {


### PR DESCRIPTION
## Summary
- enforce JSON-only instructions in summarization templates
- log full prompt and raw LLM responses in `SingleExchangeProcessor`
- warn when content is missing or summary key absent
- show fallback message when no summary is produced
- update log

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688491943ec08321956481cc8a963328