### PR TITLE
Fix context merge review summary display

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -199,3 +199,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507260854][9c9a7c][FTR][UI] Added supervised merge menu trigger
 [2507260904][73b9055][FTR][UI] Added SupervisedMergeController for stepwise merge
 [2507260918][586acc2][FTR][UI] Implemented context merge review dialog
+[2507261031][cf29e29][BUG][UI] Fixed merged context summary display

--- a/lib/widgets/context_merge_review_dialog.dart
+++ b/lib/widgets/context_merge_review_dialog.dart
@@ -39,7 +39,13 @@ class ContextMergeReviewDialog extends StatelessWidget {
             const SizedBox(height: 12),
             Text('Merged Context Summary:'),
             const SizedBox(height: 8),
-            Text(memory.summary ?? '(no summary)', style: TextStyle(fontFamily: 'monospace')),
+            Text(
+              memory.parcels
+                  .map((p) => p.summary)
+                  .whereType<String>()
+                  .join('\n\n'),
+              style: TextStyle(fontFamily: 'monospace'),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- fix merged context summary text in `ContextMergeReviewDialog`
- log context merge summary bugfix

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6884ae069f808321a0ef85833f6172b4