### PR TITLE
Fix supervised merge exchange handling

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -201,3 +201,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507260918][586acc2][FTR][UI] Implemented context merge review dialog
 [2507261031][cf29e29][BUG][UI] Fixed merged context summary display
 [2507261039][6ecd10c][FTR] Implemented supervised merge iteration flow
+[2507261047][5473a0b][FTR][LLM] Added processExchange helper and updated supervised merge

--- a/lib/memory/supervised_merge_controller.dart
+++ b/lib/memory/supervised_merge_controller.dart
@@ -16,14 +16,13 @@ class SupervisedMergeController {
     required int startIndex,
   }) async {
     final memory = ContextMemory(parcels: []);
-    final processor = SingleExchangeProcessor();
 
     for (int i = startIndex; i < exchanges.length; i++) {
       final exchange = exchanges[i];
       ContextParcel? parcel;
 
       try {
-        parcel = await processor.process(exchange);
+        parcel = await SingleExchangeProcessor.processExchange(exchange);
       } catch (e) {
         debugPrint('[SupervisedMerge] Error processing exchange $i: $e');
         continue;

--- a/lib/src/instructions/instruction_templates.dart
+++ b/lib/src/instructions/instruction_templates.dart
@@ -1,3 +1,5 @@
+import '../../models/exchange.dart';
+
 class InstructionTemplates {
   static String forStrategy(String strategy) {
     switch (strategy) {
@@ -88,4 +90,20 @@ Respond ONLY with a JSON object. Example:
   "raw": "<original text here>"
 }
 ''';
+
+  /// Builds a prompt to extract context from a single [exchange].
+  /// Returns instructions that ask the LLM for a concise, developer-focused
+  /// summary and associated metadata.
+  static String contextExtractionPrompt(Exchange exchange) {
+    return '''
+Extract a developer-focused context summary from the following conversation exchange.
+Return only JSON in the format: { "summary": "...", "tags": ["..."], "notes": "...", "confidence": float }
+
+Prompt:
+${exchange.prompt}
+
+Response:
+${exchange.response}
+''';
+  }
 }


### PR DESCRIPTION
## Summary
- enable single-exchange processing via `processExchange`
- use new helper in `SupervisedMergeController`
- provide context extraction prompt builder

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6884b11647808321bdee4ee6e3fa6ddd