### PR TITLE
Fix SingleExchangeProcessor import and response processing

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -203,3 +203,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507261039][6ecd10c][FTR] Implemented supervised merge iteration flow
 [2507261047][5473a0b][FTR][LLM] Added processExchange helper and updated supervised merge
 [2507261057][107b62e][BUG][LLM] Updated context extraction prompt and exchange processor
+[2507261109][be58f2a][BUG] Corrected import path and response handler call

--- a/lib/memory/single_exchange_processor.dart
+++ b/lib/memory/single_exchange_processor.dart
@@ -5,7 +5,7 @@ import '../models/context_parcel.dart';
 import '../models/exchange.dart';
 import '../models/llm_merge_strategy.dart';
 import '../services/llm_client.dart';
-import '../llm/instruction_templates.dart';
+import '../src/instructions/instruction_templates.dart';
 import '../debug/debug_logger.dart';
 
 /// Parses an LLM [response] into a [ContextParcel]. Returns null if parsing
@@ -168,6 +168,6 @@ $responseText''';
     }
 
     final response = await LLMClient.sendPrompt(prompt);
-    return process(response);
+    return SingleExchangeProcessor.process(response);
   }
 }


### PR DESCRIPTION
## Summary
- reference instruction templates from src folder
- delegate context extraction to SingleExchangeProcessor.process
- log update

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6884b5b3ee74832191ed93e277f65204