### PR TITLE
Fix LLM JSON parsing in processExchange

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -205,3 +205,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507261057][107b62e][BUG][LLM] Updated context extraction prompt and exchange processor
 [2507261109][be58f2a][BUG] Corrected import path and response handler call
 [2507261121][3f735c][REF] Switched instruction templates to use MergeStrategy enum
+[2507261128][0b62b9][BUG][LLM] Fixed JSON parsing call in processExchange


### PR DESCRIPTION
## Summary
- move LLM response parsing logic into `SingleExchangeProcessor.parseLLMResponse`
- call new parser from `processExchange`
- log entry for fix

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6884baf621988321865045d2bd5dd57f