### PR TITLE
Add merge completion dialog for supervised workflow

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -206,3 +206,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507261109][be58f2a][BUG] Corrected import path and response handler call
 [2507261121][3f735c][REF] Switched instruction templates to use MergeStrategy enum
 [2507261128][0b62b9][BUG][LLM] Fixed JSON parsing call in processExchange
+[2507261136][ee0e85a][FTR][UI] Added merge completion dialog with summary copy option

--- a/lib/memory/supervised_merge_controller.dart
+++ b/lib/memory/supervised_merge_controller.dart
@@ -5,6 +5,7 @@ import '../models/context_parcel.dart';
 import '../models/exchange.dart';
 import 'single_exchange_processor.dart';
 import '../widgets/context_merge_review_dialog.dart';
+import '../widgets/context_merge_complete_dialog.dart';
 
 /// Controls a step-by-step supervised merge process.
 class SupervisedMergeController {
@@ -59,6 +60,11 @@ class SupervisedMergeController {
         break;
       }
     }
+
+    await showDialog(
+      context: context,
+      builder: (_) => ContextMergeCompleteDialog(memory: memory),
+    );
 
     debugPrint('[SupervisedMerge] Completed merge process.');
   }

--- a/lib/widgets/context_merge_complete_dialog.dart
+++ b/lib/widgets/context_merge_complete_dialog.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../models/context_memory.dart';
+
+class ContextMergeCompleteDialog extends StatelessWidget {
+  final ContextMemory memory;
+
+  const ContextMergeCompleteDialog({required this.memory, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final summaryText =
+        memory.parcels.map((p) => p.summary).whereType<String>().join('\n\n');
+
+    return AlertDialog(
+      title: const Text('Merge Completed'),
+      content: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Merged Context Summary:'),
+            const SizedBox(height: 8),
+            Text(
+              summaryText.isEmpty ? '(no content)' : summaryText,
+              style: const TextStyle(fontFamily: 'monospace'),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Clipboard.setData(ClipboardData(text: summaryText));
+            Navigator.of(context).pop();
+          },
+          child: const Text('Copy Summary'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- finalize supervised merge UX by showing a completion dialog
- allow copying the merged summary via the dialog actions
- show completion dialog after merge loop or cancellation
- log the addition

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6884bd6499cc8321807b9fd61d7fa6a0