### PR TITLE
Improve LLM response parsing

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -207,3 +207,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507261121][3f735c][REF] Switched instruction templates to use MergeStrategy enum
 [2507261128][0b62b9][BUG][LLM] Fixed JSON parsing call in processExchange
 [2507261136][ee0e85a][FTR][UI] Added merge completion dialog with summary copy option
+[2507261146][8121a6e][BUG][LLM] Hardened LLM response parsing with debug logs


### PR DESCRIPTION
## Summary
- add `flutter/foundation.dart` import for debugPrint
- make `SingleExchangeProcessor.parseLLMResponse` resilient with detailed debug logs
- log new improvement

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_b_6884bf7b06208321acfa1a6100563823