### PR TITLE
Fix ContextParcel confidence parsing

### DIFF
--- a/CODEXLOG_CURRENT.md
+++ b/CODEXLOG_CURRENT.md
@@ -208,3 +208,4 @@ This file records all Codex-generated changes and implementations in this projec
 [2507261128][0b62b9][BUG][LLM] Fixed JSON parsing call in processExchange
 [2507261136][ee0e85a][FTR][UI] Added merge completion dialog with summary copy option
 [2507261146][8121a6e][BUG][LLM] Hardened LLM response parsing with debug logs
+[2507261201][65b75de][ERR][DATA] Fixed confidence parsing in ContextParcel.fromJson

--- a/cli/context_builder.dart
+++ b/cli/context_builder.dart
@@ -428,7 +428,7 @@ Future<({ _FileStats? stats, String? failed })> _processFile(
     if (results['debug'] == true) {
       for (int i = 0; i < memory.parcels.length; i++) {
         final conf = memory.parcels[i].confidence;
-        if (conf.isNotEmpty) {
+        if (conf != null) {
           stdout.writeln('  Parcel ${i + 1} confidence: $conf');
         }
       }

--- a/lib/memory/iterative_merge_engine.dart
+++ b/lib/memory/iterative_merge_engine.dart
@@ -128,6 +128,7 @@ class IterativeMergeEngine {
       mergeHistory: mergeHistory,
       tags: context.tags,
       assumptions: context.assumptions,
+      notes: context.notes,
       confidence: context.confidence,
       manualEdits: context.manualEdits,
     );

--- a/lib/models/context_parcel.dart
+++ b/lib/models/context_parcel.dart
@@ -14,8 +14,11 @@ class ContextParcel {
   /// Optional assumptions inferred or explicitly stated
   final List<String> assumptions;
 
-  /// Optional confidence values for parts of the summary or tags
-  final Map<String, double> confidence;
+  /// Optional notes or caveats provided by the LLM.
+  final String? notes;
+
+  /// Overall confidence score for this parcel.
+  final double? confidence;
 
   /// Records any manual edits applied during merge review.
   final List<ManualEdit> manualEdits;
@@ -37,7 +40,8 @@ class ContextParcel {
     required this.mergeHistory,
     this.tags = const [],
     this.assumptions = const [],
-    this.confidence = const {},
+    this.notes,
+    this.confidence,
     this.manualEdits = const [],
     this.feature,
     this.system,
@@ -63,9 +67,16 @@ class ContextParcel {
       mergeHistory: List<int>.from(
         json['mergeHistory'] ?? json['contributingExchangeIds'] ?? [],
       ),
-      tags: List<String>.from(json['tags'] ?? []),
-      assumptions: List<String>.from(json['assumptions'] ?? []),
-      confidence: Map<String, double>.from(json['confidence'] ?? {}),
+      tags: json['tags'] is List
+          ? List<String>.from(json['tags'])
+          : <String>[],
+      assumptions: json['assumptions'] is List
+          ? List<String>.from(json['assumptions'])
+          : <String>[],
+      notes: json['notes'] as String?,
+      confidence: (json['confidence'] is num)
+          ? (json['confidence'] as num).toDouble()
+          : null,
       manualEdits: (json['manualEdits'] as List<dynamic>? ?? [])
           .map((e) => ManualEdit.fromJson(Map<String, dynamic>.from(e)))
           .toList(),
@@ -81,7 +92,8 @@ class ContextParcel {
         'mergeHistory': mergeHistory,
         'tags': tags,
         'assumptions': assumptions,
-        'confidence': confidence,
+        if (notes != null) 'notes': notes,
+        if (confidence != null) 'confidence': confidence,
         'manualEdits': manualEdits.map((e) => e.toJson()).toList(),
         if (inlineTags.isNotEmpty)
           'inlineTags': inlineTags.map((e) => e.label).toList(),
@@ -154,7 +166,8 @@ ContextParcel(
   mergeHistory: [101, 102, 105],
   tags: ["bug", "loader", "streaming"],
   assumptions: ["File was too large for previous parser"],
-  confidence: {"summary": 0.95}
+  notes: "No major gaps",
+  confidence: 0.95
 );
 */
 
@@ -166,9 +179,7 @@ ContextParcel(
   "mergeHistory": [12, 15, 16],
   "tags": ["bug", "loader", "json"],
   "assumptions": ["Data exceeds buffer size"],
-  "confidence": {
-    "summary": 0.93,
-    "tags": 0.8
-  }
+  "notes": "Edge case when file is empty",
+  "confidence": 0.93
 }
 */

--- a/lib/routing/context_router.dart
+++ b/lib/routing/context_router.dart
@@ -117,6 +117,7 @@ class ContextRouter {
       mergeHistory: parcel.mergeHistory,
       tags: parcel.tags,
       assumptions: parcel.assumptions,
+      notes: parcel.notes,
       confidence: parcel.confidence,
       manualEdits: parcel.manualEdits,
       feature: feature ?? parcel.feature,

--- a/lib/services/manual_reviewer.dart
+++ b/lib/services/manual_reviewer.dart
@@ -73,6 +73,7 @@ class ManualReviewer {
                       .where((e) => e.isNotEmpty)
                       .toList()
                   : parcel.assumptions,
+          notes: parcel.notes,
           confidence: parcel.confidence,
           manualEdits: parcel.manualEdits,
           feature: featureInput != null && featureInput.trim().isNotEmpty
@@ -97,6 +98,7 @@ class ManualReviewer {
           mergeHistory: edited.mergeHistory,
           tags: edited.tags,
           assumptions: edited.assumptions,
+          notes: edited.notes,
           confidence: edited.confidence,
           manualEdits: [...parcel.manualEdits, record],
           feature: edited.feature,


### PR DESCRIPTION
## Summary
- parse `confidence` as a numeric value in `ContextParcel.fromJson`
- add optional `notes` and numeric `confidence` fields to `ContextParcel`
- propagate new fields in manual review, routing and merge engine
- update debug output for numeric confidence
- log the fix

## Testing
- ❌ `dart format lib/models/context_parcel.dart` *(failed: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_6884c1f83a208321a04db07265dc8f85